### PR TITLE
fix: prevent false configuration changed warning

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -275,14 +275,18 @@ function ReShadeInstallerSection() {
             onConfirm={async (selectedShaders: string[]) => {
               try {
                 setInstalling(true);
+
+                // Save shader preferences so future config comparisons work correctly
+                await saveShaderPreferences(selectedShaders);
+
                 const result = await runInstallReShade(
-                  addonEnabled, 
-                  selectedVersion.value, 
-                  autoHdrEnabled, 
+                  addonEnabled,
+                  selectedVersion.value,
+                  autoHdrEnabled,
                   selectedShaders
                 );
                 setInstallResult(result);
-                
+
                 // If installation was successful, reload installed config
                 if (result.status === "success") {
                   const configResult = await loadInstalledConfiguration();


### PR DESCRIPTION
I got the "Configuration Changed" warning repeatedly, and found that it was because the selected shaders were only saved by through "Select Packages to Install" and not through the prompt that appears when hitting "Install ReShade ${version}" if not selecting shaders beforehand.

The array of selected shaders are compared to the shaders installed, so that's the reason for the "Configuration Changed" warning. It sees that no shaders should be installed, while shaders actually are installed (since it was selected in the prompt, and not through the "Select Packages to Install" button)

Possibly closes issue [#53](https://github.com/itsOwen/LetMeReShade/issues/53) in the upstream repo 