### PR TITLE
fix: add version number to labels

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -104,8 +104,8 @@ function ReShadeInstallerSection() {
   const [preferencesInfo, setPreferencesInfo] = useState<any>(null);
 
   const versionOptions: VersionOption[] = [
-    { label: 'ReShade Latest', value: 'latest' },
-    { label: 'ReShade Last Version', value: 'last' },
+    { label: 'ReShade Latest (6.5.1)', value: 'latest' },
+    { label: 'ReShade Last Version (6.5.1)', value: 'last' },
   ];
 
   useEffect(() => {


### PR DESCRIPTION
Both `last` and `latest` options are actually the same binaries (6.5.1), for some reason, so just adding the version to the label to avoid confusion. 

Will update this properly with #4 