### PR TITLE
ci: add renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:weekends",
+    "group:allNonMajor"
+  ],
+  "minimumReleaseAge": "3 days",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@decky/"],
+      "groupName": "decky packages"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `renovate.json` with:
- 3-day minimum release age for all packages
- Weekend schedule
- All non-major updates grouped into a single PR
- Decky packages grouped together
- Lock file maintenance enabled
- No automerge

**Manual step after merge:** Install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo.