### PR TITLE
ci: improve CI testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint:js
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
   lint-py:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +54,7 @@ jobs:
       - lint-bash
       - lint-js
       - lint-py
+      - typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'format --check'
 
   build:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --prod
+        continue-on-error: true
       - run: pnpm build
       - run: tar czf letusreshade-decky.tgz dist
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,23 @@ jobs:
         with:
           args: 'format --check'
 
+  test-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest tests/ -v
+
   build:
     needs:
       - lint-bash
       - lint-js
       - lint-py
       - typecheck
+      - test-python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,21 +88,17 @@ jobs:
         with:
           name: letusreshade-decky
           path: letusreshade-decky.tgz
-  # Commented out until tests are implemented
-  # test:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - uses: actions/download-artifact@v5
-  #       with:
-  #         name: letusreshade-decky
-  #     - run: |
-  #         tar xf letusreshade-decky.tgz
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 24
-  #         cache: pnpm
-  #     - run: pnpm install --frozen-lockfile
-  #     - run: pnpm test
+
+  test-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,8 @@
 pnpm lint:js
 pnpm lint:sh
 pnpm lint:py
+python3 -m ruff format --check main.py tests/
 pnpm typecheck
+python3 -m pytest tests/ -q
+pnpm test
 pnpm build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 pnpm lint:js
 pnpm lint:sh
 pnpm lint:py
+pnpm typecheck
 pnpm build

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/decky.pyi
+++ b/decky.pyi
@@ -125,7 +125,6 @@ e.g.: `/home/deck/homebrew/logs/decky-plugin-template/plugin.log`
 Migration helpers
 """
 
-
 def migrate_any(target_dir: str, *files_or_directories: str) -> dict[str, str]:
     """
     Migrate files and directories to a new location and remove old locations.
@@ -134,7 +133,6 @@ def migrate_any(target_dir: str, *files_or_directories: str) -> dict[str, str]:
 
     Returns the mapping of old -> new location.
     """
-
 
 def migrate_settings(*files_or_directories: str) -> dict[str, str]:
     """
@@ -145,7 +143,6 @@ def migrate_settings(*files_or_directories: str) -> dict[str, str]:
     Returns the mapping of old -> new location.
     """
 
-
 def migrate_runtime(*files_or_directories: str) -> dict[str, str]:
     """
     Migrate files and directories relating to plugin runtime data to the recommended location and remove old locations
@@ -155,7 +152,6 @@ def migrate_runtime(*files_or_directories: str) -> dict[str, str]:
     Returns the mapping of old -> new location.
     """
 
-
 def migrate_logs(*files_or_directories: str) -> dict[str, str]:
     """
     Migrate files and directories relating to plugin logs to the recommended location and remove old locations.
@@ -164,7 +160,6 @@ def migrate_logs(*files_or_directories: str) -> dict[str, str]:
 
     Returns the mapping of old -> new location.
     """
-
 
 """
 Logging
@@ -176,6 +171,7 @@ logger: logging.Logger
 """
 Event handling
 """
+
 # TODO better docstring im lazy
 async def emit(event: str, *args: Any) -> None:
     """

--- a/main.py
+++ b/main.py
@@ -10,6 +10,333 @@ from pathlib import Path
 import decky
 
 
+def _noop_debug(_msg):
+    """No-op logger for when no logger is provided."""
+
+
+def score_steam_executable(exe_info: dict, game_name: str, logger=None) -> float:
+    """Score a Windows executable for likelihood of being the main game exe (Steam games).
+
+    Args:
+        exe_info: dict with keys 'filename', 'relative_path', 'size_mb'
+        game_name: the game's name from Steam manifest
+        logger: optional logger with .debug() method
+
+    Returns:
+        Score between 0 and 100
+    """
+    debug = logger.debug if logger else _noop_debug
+
+    score = 50
+    filename = exe_info['filename'].lower()
+    filename_no_ext = os.path.splitext(filename)[0]
+    rel_path = exe_info['relative_path'].lower()
+    size_mb = exe_info['size_mb']
+
+    debug(f'Scoring {filename} at {rel_path}')
+
+    # Enhanced game name matching with multiple normalization approaches
+    clean_game_name = re.sub(r'[^a-z0-9]', '', game_name.lower()) if game_name else ''
+    clean_filename = re.sub(r'[^a-z0-9]', '', filename_no_ext)
+
+    # Split into words for more flexible matching
+    game_name_words = re.findall(r'[a-z0-9]+', game_name.lower()) if game_name else []
+    filename_words = re.findall(r'[a-z0-9]+', filename_no_ext)
+
+    # Calculate various types of matches
+    name_match_score = 0
+
+    # Exact matches (highest priority)
+    if clean_filename == clean_game_name:
+        name_match_score += 60
+        debug('  Exact name match: +60 (normalized names match exactly)')
+
+    # Substantial partial matches (high priority)
+    elif clean_game_name and (
+        clean_game_name in clean_filename or clean_filename in clean_game_name
+    ):
+        # Calculate how much of the string matches
+        match_ratio = max(
+            len(clean_game_name) / len(clean_filename) if len(clean_filename) > 0 else 0,
+            len(clean_filename) / len(clean_game_name) if len(clean_game_name) > 0 else 0,
+        )
+        # Scale the score based on how much of the string matches (max 45 points)
+        partial_score = min(45, int(match_ratio * 45))
+        name_match_score += partial_score
+        debug(f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})')
+
+    # Word-level matches (medium priority)
+    else:
+        # Find matching words between game name and filename
+        matching_words = set(game_name_words).intersection(set(filename_words))
+
+        if matching_words:
+            # Calculate match percentage relative to the source words
+            match_percentage = len(matching_words) / len(game_name_words) if game_name_words else 0
+            word_score = (
+                len(matching_words) * 8 * (1 + match_percentage)
+            )  # Scale based on percentage match
+            name_match_score += min(40, round(word_score))  # Cap at 40 points
+            debug(f'  Word match: +{min(40, round(word_score))} ({matching_words})')
+
+    # Common game executable names bonus
+    if any(
+        common in filename_no_ext.lower() for common in ['game', 'main', 'client', 'app', 'play']
+    ):
+        common_bonus = 15
+        name_match_score += common_bonus
+        debug(f'  Common game exe name: +{common_bonus}')
+
+    # Add the name match score to the total score
+    score += name_match_score
+
+    # Size-based scoring (reduced weights)
+    size_score = 0
+    if size_mb > 50:  # Large games
+        size_score = 10  # Reduced from 35
+    elif size_mb > 20:  # Medium games
+        size_score = 8  # Reduced from 25
+    elif size_mb > 5:  # Small games
+        size_score = 5  # Reduced from 15
+    elif size_mb > 1:  # Small but not tiny
+        size_score = 2  # Reduced from 5
+    elif size_mb < 0.5:  # Very small files (likely utilities)
+        size_score = -20  # Keep this penalty to avoid tiny utility executables
+
+    score += size_score
+    debug(f'  Size score: +{size_score} ({size_mb} MB)')
+
+    # Path-based scoring (more moderate)
+    path_score = 0
+    if 'binaries/win64' in rel_path or 'binaries\\win64' in rel_path:  # Unreal Engine pattern
+        path_score += 15  # Reduced from 25
+    elif 'bin' in rel_path:  # Common bin directory
+        path_score += 10  # Reduced from 15
+    elif 'game' in rel_path:  # Game subdirectory
+        path_score += 8  # Reduced from 10
+    elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
+        path_score += 5  # Reduced from 8
+
+    score += path_score
+    debug(f'  Path score: +{path_score}')
+
+    # Special patterns from real data (more moderate)
+    special_score = 0
+    if 'shipping' in filename:  # Unreal shipping builds
+        special_score += 15  # Reduced from 20
+    elif 'win64' in filename:  # 64-bit indicator
+        special_score += 5  # Reduced from 8
+    elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
+        special_score -= 25  # Increased penalty from 15
+
+    score += special_score
+    if special_score != 0:
+        debug(f'  Special pattern score: {special_score}')
+
+    # Moderate penalty for deep nesting
+    path_depth = rel_path.count('/') + rel_path.count('\\')
+    if path_depth > 4:  # Increased threshold
+        depth_penalty = (path_depth - 4) * 3
+        score -= depth_penalty
+        debug(f'  Deep nesting penalty: -{depth_penalty}')
+
+    # Cap score between 0 and 100
+    score = max(0, min(100, score))
+
+    # Round to 1 decimal place for cleaner display
+    score = round(score, 1)
+
+    debug(f'  Final score for {filename}: {score} (name match: {name_match_score})')
+    return score
+
+
+def score_heroic_executable(exe_info: dict, game_name: str, game_path: str, logger=None) -> float:
+    """Score a Windows executable for likelihood of being the main game exe (Heroic games).
+
+    Args:
+        exe_info: dict with keys 'filename', 'relative_path', 'size_mb'
+        game_name: the game's display name
+        game_path: the game's installation directory path
+        logger: optional logger with .debug() method
+
+    Returns:
+        Score between 0 and 100 (0 means filtered out as utility)
+    """
+    debug = logger.debug if logger else _noop_debug
+
+    score = 50  # Start with a base score
+    filename = exe_info['filename'].lower()
+    filename_no_ext = os.path.splitext(filename)[0]  # Remove extension
+    rel_path = exe_info['relative_path'].lower()
+    size_mb = exe_info['size_mb']
+
+    debug(f'Scoring {filename} at {rel_path}')
+
+    # LESS aggressive utility filtering - only skip very obvious ones
+    utility_keywords = ['unins', 'setup', 'vcredist', 'directx', 'redist']
+    if any(skip in filename for skip in utility_keywords):
+        debug(f'  Utility file detected: {filename}')
+        return 0
+
+    # Enhanced game name matching with multiple normalization approaches
+    # 1. Get directory name and clean game name
+    dir_name = os.path.basename(game_path).lower()
+    clean_game_name = game_name.lower()
+
+    # 2. Clean up names by removing spaces, special chars, etc.
+    clean_dir_name = re.sub(r'[^a-z0-9]', '', dir_name)
+    norm_game_name = re.sub(r'[^a-z0-9]', '', clean_game_name)
+    norm_filename = re.sub(r'[^a-z0-9]', '', filename_no_ext)
+
+    # 3. Split into words for more flexible matching
+    dir_words = re.findall(r'[a-z0-9]+', dir_name)
+    game_name_words = re.findall(r'[a-z0-9]+', clean_game_name)
+    filename_words = re.findall(r'[a-z0-9]+', filename_no_ext)
+
+    # Log the normalized values for debugging
+    debug(
+        f"  Normalized names - Dir: '{clean_dir_name}', Game: '{norm_game_name}', File: '{norm_filename}'"
+    )
+
+    # 4. Calculate various types of matches
+    name_match_score = 0
+
+    # Exact matches (highest priority)
+    if norm_filename in (norm_game_name, clean_dir_name):
+        name_match_score += 60
+        debug('  Exact name match: +60 (normalized names match exactly)')
+
+    # Handle specific cases like "among us.exe" vs "amongus" folder
+    elif (
+        norm_filename.replace(' ', '') == norm_game_name
+        or norm_game_name.replace(' ', '') == norm_filename
+        or norm_filename.replace(' ', '') == clean_dir_name
+        or clean_dir_name.replace(' ', '') == norm_filename
+    ):
+        name_match_score += 55
+        debug('  Space-normalized match: +55')
+
+    # Substantial partial matches (high priority)
+    elif (
+        norm_game_name in norm_filename
+        or norm_filename in norm_game_name
+        or clean_dir_name in norm_filename
+        or norm_filename in clean_dir_name
+    ):
+        # Calculate how much of the string matches
+        match_ratio = max(
+            len(norm_game_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
+            len(norm_filename) / len(norm_game_name) if len(norm_game_name) > 0 else 0,
+            len(clean_dir_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
+            len(norm_filename) / len(clean_dir_name) if len(clean_dir_name) > 0 else 0,
+        )
+        # Scale the score based on how much of the string matches (max 45 points)
+        partial_score = min(45, int(match_ratio * 45))
+        name_match_score += partial_score
+        debug(f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})')
+
+        # Extra case for when folder has additional characters (like "DREDGEmKMzX" vs "DREDGE.exe")
+        if (
+            norm_filename in clean_dir_name
+            and len(norm_filename) > 4
+            and len(norm_filename) >= len(clean_dir_name) * 0.5
+        ):
+            extra_bonus = 15
+            name_match_score += extra_bonus
+            debug(f'  Extra partial match bonus: +{extra_bonus} (likely main game exe)')
+
+    # Word-level matches (medium priority)
+    else:
+        # Find matching words between game name/dir and filename
+        matching_game_words = set(game_name_words).intersection(set(filename_words))
+        matching_dir_words = set(dir_words).intersection(set(filename_words))
+
+        # Use the best match (dir or game name)
+        best_matches = (
+            matching_game_words
+            if len(matching_game_words) > len(matching_dir_words)
+            else matching_dir_words
+        )
+        if best_matches:
+            # Calculate match percentage relative to the source words
+            match_percentage = len(best_matches) / len(game_name_words) if game_name_words else 0
+            word_score = (
+                len(best_matches) * 5.0 * (1 + match_percentage)
+            )  # Scale based on percentage match
+            name_match_score += min(40, round(word_score))  # Cap at 40 points
+            debug(f'  Word match: +{min(40, round(word_score))} ({best_matches})')
+
+    # Common game executable names bonus
+    if any(
+        common in filename_no_ext.lower() for common in ['game', 'main', 'client', 'app', 'play']
+    ):
+        common_bonus = 15
+        name_match_score += common_bonus
+        debug(f'  Common game exe name: +{common_bonus}')
+
+    # Add the name match score to the total score
+    score += name_match_score
+
+    # Size-based scoring (reduced weights)
+    size_score = 0
+    if size_mb > 50:  # Large games
+        size_score = 10  # Reduced from 35
+    elif size_mb > 20:  # Medium games
+        size_score = 8  # Reduced from 25
+    elif size_mb > 5:  # Small games
+        size_score = 5  # Reduced from 15
+    elif size_mb > 1:  # Small but not tiny
+        size_score = 2  # Reduced from 5
+    elif size_mb < 0.5:  # Very small files (likely utilities)
+        size_score = -10  # Reduced from 20
+
+    score += size_score
+    debug(f'  Size score: +{size_score} ({size_mb} MB)')
+
+    # Path-based scoring
+    path_score = 0
+    if 'binaries/win64' in rel_path or 'binaries\\win64' in rel_path:  # Unreal Engine pattern
+        path_score += 15  # Reduced from 25
+    elif 'bin' in rel_path:  # Common bin directory
+        path_score += 10  # Reduced from 15
+    elif 'game' in rel_path:  # Game subdirectory
+        path_score += 8  # Reduced from 10
+    elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
+        path_score += 5  # Reduced from 8
+
+    score += path_score
+    debug(f'  Path score: +{path_score}')
+
+    # Special patterns scoring
+    special_score = 0
+    if 'shipping' in filename:  # Unreal shipping builds
+        special_score += 15  # Reduced from 20
+    elif 'win64' in filename:  # 64-bit indicator
+        special_score += 5  # Reduced from 8
+    elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
+        special_score -= 25  # Increased penalty from 15
+
+    score += special_score
+    if special_score != 0:
+        debug(f'  Special pattern score: {special_score}')
+
+    # Moderate penalty for deep nesting
+    path_depth = rel_path.count('/') + rel_path.count('\\')
+    if path_depth > 4:  # Increased threshold
+        depth_penalty = (path_depth - 4) * 3
+        score -= depth_penalty
+        debug(f'  Deep nesting penalty: -{depth_penalty}')
+
+    # Cap score between 0 and 100
+    score = max(0, min(100, score))
+
+    # Round to 1 decimal place for cleaner display
+    score = round(score, 1)
+
+    debug(f'  Final score for {filename}: {score} (name match: {name_match_score})')
+    return score
+
+
 class Plugin:
     def __init__(self):
         self.environment = {
@@ -392,149 +719,10 @@ class Plugin:
                 f'Found {len(main_windows_executables)} Windows executables for scoring'
             )
 
-            # ENHANCED SCORING for Windows executables (keeping existing logic)
-            def score_executable(exe_info):
-                score = 50
-                filename = exe_info['filename'].lower()
-                filename_no_ext = os.path.splitext(filename)[0]
-                rel_path = exe_info['relative_path'].lower()
-                size_mb = exe_info['size_mb']
-
-                decky.logger.debug(f'Scoring {filename} at {rel_path}')
-
-                # Enhanced game name matching with multiple normalization approaches
-                clean_game_name = re.sub(r'[^a-z0-9]', '', game_name.lower()) if game_name else ''
-                clean_filename = re.sub(r'[^a-z0-9]', '', filename_no_ext)
-
-                # Split into words for more flexible matching
-                game_name_words = re.findall(r'[a-z0-9]+', game_name.lower()) if game_name else []
-                filename_words = re.findall(r'[a-z0-9]+', filename_no_ext)
-
-                # Calculate various types of matches
-                name_match_score = 0
-
-                # Exact matches (highest priority)
-                if clean_filename == clean_game_name:
-                    name_match_score += 60
-                    decky.logger.debug('  Exact name match: +60 (normalized names match exactly)')
-
-                # Substantial partial matches (high priority)
-                elif clean_game_name and (
-                    clean_game_name in clean_filename or clean_filename in clean_game_name
-                ):
-                    # Calculate how much of the string matches
-                    match_ratio = max(
-                        len(clean_game_name) / len(clean_filename)
-                        if len(clean_filename) > 0
-                        else 0,
-                        len(clean_filename) / len(clean_game_name)
-                        if len(clean_game_name) > 0
-                        else 0,
-                    )
-                    # Scale the score based on how much of the string matches (max 45 points)
-                    partial_score = min(45, int(match_ratio * 45))
-                    name_match_score += partial_score
-                    decky.logger.debug(
-                        f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})'
-                    )
-
-                # Word-level matches (medium priority)
-                else:
-                    # Find matching words between game name and filename
-                    matching_words = set(game_name_words).intersection(set(filename_words))
-
-                    if matching_words:
-                        # Calculate match percentage relative to the source words
-                        match_percentage = (
-                            len(matching_words) / len(game_name_words) if game_name_words else 0
-                        )
-                        word_score = (
-                            len(matching_words) * 8 * (1 + match_percentage)
-                        )  # Scale based on percentage match
-                        name_match_score += min(40, round(word_score))  # Cap at 40 points
-                        decky.logger.debug(
-                            f'  Word match: +{min(40, round(word_score))} ({matching_words})'
-                        )
-
-                # Common game executable names bonus
-                if any(
-                    common in filename_no_ext.lower()
-                    for common in ['game', 'main', 'client', 'app', 'play']
-                ):
-                    common_bonus = 15
-                    name_match_score += common_bonus
-                    decky.logger.debug(f'  Common game exe name: +{common_bonus}')
-
-                # Add the name match score to the total score
-                score += name_match_score
-
-                # Size-based scoring (reduced weights)
-                size_score = 0
-                if size_mb > 50:  # Large games
-                    size_score = 10  # Reduced from 35
-                elif size_mb > 20:  # Medium games
-                    size_score = 8  # Reduced from 25
-                elif size_mb > 5:  # Small games
-                    size_score = 5  # Reduced from 15
-                elif size_mb > 1:  # Small but not tiny
-                    size_score = 2  # Reduced from 5
-                elif size_mb < 0.5:  # Very small files (likely utilities)
-                    size_score = -20  # Keep this penalty to avoid tiny utility executables
-
-                score += size_score
-                decky.logger.debug(f'  Size score: +{size_score} ({size_mb} MB)')
-
-                # Path-based scoring (more moderate)
-                path_score = 0
-                if (
-                    'binaries/win64' in rel_path or 'binaries\\win64' in rel_path
-                ):  # Unreal Engine pattern
-                    path_score += 15  # Reduced from 25
-                elif 'bin' in rel_path:  # Common bin directory
-                    path_score += 10  # Reduced from 15
-                elif 'game' in rel_path:  # Game subdirectory
-                    path_score += 8  # Reduced from 10
-                elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
-                    path_score += 5  # Reduced from 8
-
-                score += path_score
-                decky.logger.debug(f'  Path score: +{path_score}')
-
-                # Special patterns from real data (more moderate)
-                special_score = 0
-                if 'shipping' in filename:  # Unreal shipping builds
-                    special_score += 15  # Reduced from 20
-                elif 'win64' in filename:  # 64-bit indicator
-                    special_score += 5  # Reduced from 8
-                elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
-                    special_score -= 25  # Increased penalty from 15
-
-                score += special_score
-                if special_score != 0:
-                    decky.logger.debug(f'  Special pattern score: {special_score}')
-
-                # Moderate penalty for deep nesting
-                path_depth = rel_path.count('/') + rel_path.count('\\')
-                if path_depth > 4:  # Increased threshold
-                    depth_penalty = (path_depth - 4) * 3
-                    score -= depth_penalty
-                    decky.logger.debug(f'  Deep nesting penalty: -{depth_penalty}')
-
-                # Cap score between 0 and 100
-                score = max(0, min(100, score))
-
-                # Round to 1 decimal place for cleaner display
-                score = round(score, 1)
-
-                decky.logger.debug(
-                    f'  Final score for {filename}: {score} (name match: {name_match_score})'
-                )
-                return score
-
             # Score all Windows executables
             scored_executables = []
             for exe_info in main_windows_executables:
-                score = score_executable(exe_info)
+                score = score_steam_executable(exe_info, game_name, decky.logger)
                 if score > 0:
                     scored_executables.append({**exe_info, 'score': score})
                 else:
@@ -694,197 +882,10 @@ class Plugin:
 
             decky.logger.info(f'Found {len(all_executables)} total executables')
 
-            # Enhanced filtering based on discovered patterns
-            def score_executable(exe_info):
-                score = 50  # Start with a base score
-                filename = exe_info['filename'].lower()
-                filename_no_ext = os.path.splitext(filename)[0]  # Remove extension
-                rel_path = exe_info['relative_path'].lower()
-                size_mb = exe_info['size_mb']
-
-                decky.logger.debug(f'Scoring {filename} at {rel_path}')
-
-                # LESS aggressive utility filtering - only skip very obvious ones
-                utility_keywords = ['unins', 'setup', 'vcredist', 'directx', 'redist']
-                if any(skip in filename for skip in utility_keywords):
-                    decky.logger.debug(f'  Utility file detected: {filename}')
-                    return 0
-
-                # Enhanced game name matching with multiple normalization approaches
-                # 1. Get directory name and clean game name
-                dir_name = os.path.basename(game_path).lower()
-                clean_game_name = game_name.lower()
-
-                # 2. Clean up names by removing spaces, special chars, etc.
-                clean_dir_name = re.sub(r'[^a-z0-9]', '', dir_name)
-                norm_game_name = re.sub(r'[^a-z0-9]', '', clean_game_name)
-                norm_filename = re.sub(r'[^a-z0-9]', '', filename_no_ext)
-
-                # 3. Split into words for more flexible matching
-                dir_words = re.findall(r'[a-z0-9]+', dir_name)
-                game_name_words = re.findall(r'[a-z0-9]+', clean_game_name)
-                filename_words = re.findall(r'[a-z0-9]+', filename_no_ext)
-
-                # Log the normalized values for debugging
-                decky.logger.debug(
-                    f"  Normalized names - Dir: '{clean_dir_name}', Game: '{norm_game_name}', File: '{norm_filename}'"
-                )
-
-                # 4. Calculate various types of matches
-                name_match_score = 0
-
-                # Exact matches (highest priority)
-                if norm_filename in (norm_game_name, clean_dir_name):
-                    name_match_score += 60
-                    decky.logger.debug('  Exact name match: +60 (normalized names match exactly)')
-
-                # Handle specific cases like "among us.exe" vs "amongus" folder
-                elif (
-                    norm_filename.replace(' ', '') == norm_game_name
-                    or norm_game_name.replace(' ', '') == norm_filename
-                    or norm_filename.replace(' ', '') == clean_dir_name
-                    or clean_dir_name.replace(' ', '') == norm_filename
-                ):
-                    name_match_score += 55
-                    decky.logger.debug('  Space-normalized match: +55')
-
-                # Substantial partial matches (high priority)
-                elif (
-                    norm_game_name in norm_filename
-                    or norm_filename in norm_game_name
-                    or clean_dir_name in norm_filename
-                    or norm_filename in clean_dir_name
-                ):
-                    # Calculate how much of the string matches
-                    match_ratio = max(
-                        len(norm_game_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
-                        len(norm_filename) / len(norm_game_name) if len(norm_game_name) > 0 else 0,
-                        len(clean_dir_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
-                        len(norm_filename) / len(clean_dir_name) if len(clean_dir_name) > 0 else 0,
-                    )
-                    # Scale the score based on how much of the string matches (max 45 points)
-                    partial_score = min(45, int(match_ratio * 45))
-                    name_match_score += partial_score
-                    decky.logger.debug(
-                        f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})'
-                    )
-
-                    # Extra case for when folder has additional characters (like "DREDGEmKMzX" vs "DREDGE.exe")
-                    if (
-                        norm_filename in clean_dir_name
-                        and len(norm_filename) > 4
-                        and len(norm_filename) >= len(clean_dir_name) * 0.5
-                    ):
-                        extra_bonus = 15
-                        name_match_score += extra_bonus
-                        decky.logger.debug(
-                            f'  Extra partial match bonus: +{extra_bonus} (likely main game exe)'
-                        )
-
-                # Word-level matches (medium priority)
-                else:
-                    # Find matching words between game name/dir and filename
-                    matching_game_words = set(game_name_words).intersection(set(filename_words))
-                    matching_dir_words = set(dir_words).intersection(set(filename_words))
-
-                    # Use the best match (dir or game name)
-                    best_matches = (
-                        matching_game_words
-                        if len(matching_game_words) > len(matching_dir_words)
-                        else matching_dir_words
-                    )
-                    if best_matches:
-                        # Calculate match percentage relative to the source words
-                        match_percentage = (
-                            len(best_matches) / len(game_name_words) if game_name_words else 0
-                        )
-                        word_score = (
-                            len(best_matches) * 5.0 * (1 + match_percentage)
-                        )  # Scale based on percentage match
-                        name_match_score += min(40, round(word_score))  # Cap at 40 points
-                        decky.logger.debug(
-                            f'  Word match: +{min(40, round(word_score))} ({best_matches})'
-                        )
-
-                # Common game executable names bonus
-                if any(
-                    common in filename_no_ext.lower()
-                    for common in ['game', 'main', 'client', 'app', 'play']
-                ):
-                    common_bonus = 15
-                    name_match_score += common_bonus
-                    decky.logger.debug(f'  Common game exe name: +{common_bonus}')
-
-                # Add the name match score to the total score
-                score += name_match_score
-
-                # Size-based scoring (reduced weights)
-                size_score = 0
-                if size_mb > 50:  # Large games
-                    size_score = 10  # Reduced from 35
-                elif size_mb > 20:  # Medium games
-                    size_score = 8  # Reduced from 25
-                elif size_mb > 5:  # Small games
-                    size_score = 5  # Reduced from 15
-                elif size_mb > 1:  # Small but not tiny
-                    size_score = 2  # Reduced from 5
-                elif size_mb < 0.5:  # Very small files (likely utilities)
-                    size_score = -10  # Reduced from 20
-
-                score += size_score
-                decky.logger.debug(f'  Size score: +{size_score} ({size_mb} MB)')
-
-                # Path-based scoring
-                path_score = 0
-                if (
-                    'binaries/win64' in rel_path or 'binaries\\win64' in rel_path
-                ):  # Unreal Engine pattern
-                    path_score += 15  # Reduced from 25
-                elif 'bin' in rel_path:  # Common bin directory
-                    path_score += 10  # Reduced from 15
-                elif 'game' in rel_path:  # Game subdirectory
-                    path_score += 8  # Reduced from 10
-                elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
-                    path_score += 5  # Reduced from 8
-
-                score += path_score
-                decky.logger.debug(f'  Path score: +{path_score}')
-
-                # Special patterns scoring
-                special_score = 0
-                if 'shipping' in filename:  # Unreal shipping builds
-                    special_score += 15  # Reduced from 20
-                elif 'win64' in filename:  # 64-bit indicator
-                    special_score += 5  # Reduced from 8
-                elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
-                    special_score -= 25  # Increased penalty from 15
-
-                score += special_score
-                if special_score != 0:
-                    decky.logger.debug(f'  Special pattern score: {special_score}')
-
-                # Moderate penalty for deep nesting
-                path_depth = rel_path.count('/') + rel_path.count('\\')
-                if path_depth > 4:  # Increased threshold
-                    depth_penalty = (path_depth - 4) * 3
-                    score -= depth_penalty
-                    decky.logger.debug(f'  Deep nesting penalty: -{depth_penalty}')
-
-                # Cap score between 0 and 100
-                score = max(0, min(100, score))
-
-                # Round to 1 decimal place for cleaner display
-                score = round(score, 1)
-
-                decky.logger.debug(
-                    f'  Final score for {filename}: {score} (name match: {name_match_score})'
-                )
-                return score
-
             # Score all executables
             scored_executables = []
             for exe_info in all_executables:
-                score = score_executable(exe_info)
+                score = score_heroic_executable(exe_info, game_name, game_path, decky.logger)
                 if score > 0:
                     scored_executables.append({**exe_info, 'score': score})
                 else:
@@ -896,7 +897,7 @@ class Plugin:
                     'All executables filtered out, using less restrictive filtering'
                 )
                 for exe_info in all_executables:
-                    score = score_executable(exe_info)
+                    score = score_heroic_executable(exe_info, game_name, game_path, decky.logger)
                     if score >= 0:
                         scored_executables.append({**exe_info, 'score': score})
 
@@ -904,7 +905,14 @@ class Plugin:
                 # Last resort: include everything
                 decky.logger.warning('Still no executables, including all found')
                 for exe_info in all_executables:
-                    scored_executables.append({**exe_info, 'score': score_executable(exe_info)})
+                    scored_executables.append(
+                        {
+                            **exe_info,
+                            'score': score_heroic_executable(
+                                exe_info, game_name, game_path, decky.logger
+                            ),
+                        }
+                    )
 
             # Sort by score (highest first) and take top 5
             scored_executables.sort(key=lambda x: x['score'], reverse=True)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ class Plugin:
             'FORCE_RESHADE_UPDATE_CHECK': '0',
             'RESHADE_ADDON_SUPPORT': '0',
             'RESHADE_VERSION': '6.7.3',
-            'AUTOHDR_ENABLED': '0'
+            'AUTOHDR_ENABLED': '0',
         }
         # Main paths for ReShade
         self.main_path = os.path.join(self.environment['XDG_DATA_HOME'], 'reshade')
@@ -38,49 +38,51 @@ class Plugin:
         plugin_dir = Path(decky.DECKY_PLUGIN_DIR)
 
         # Check defaults/assets first (development)
-        defaults_assets = plugin_dir / "defaults" / "assets"
+        defaults_assets = plugin_dir / 'defaults' / 'assets'
         if defaults_assets.exists():
-            decky.logger.info(f"Using assets from: {defaults_assets}")
+            decky.logger.info(f'Using assets from: {defaults_assets}')
             return defaults_assets
 
         # Check assets (decky store installation)
-        assets = plugin_dir / "assets"
+        assets = plugin_dir / 'assets'
         if assets.exists():
-            decky.logger.info(f"Using assets from: {assets}")
+            decky.logger.info(f'Using assets from: {assets}')
             return assets
 
         # Fallback to defaults/assets even if it doesn't exist (for error reporting)
-        decky.logger.warning(f"Neither {defaults_assets} nor {assets} exists, defaulting to {defaults_assets}")
+        decky.logger.warning(
+            f'Neither {defaults_assets} nor {assets} exists, defaulting to {defaults_assets}'
+        )
         return defaults_assets
 
     async def _main(self):
         assets_dir = self._get_assets_dir()
-        for script in assets_dir.glob("*.sh"):
+        for script in assets_dir.glob('*.sh'):
             script.chmod(0o755)
-        decky.logger.info("ReShade plugin loaded")
+        decky.logger.info('ReShade plugin loaded')
 
     async def _unload(self):
-        decky.logger.info("ReShade plugin unloaded")
+        decky.logger.info('ReShade plugin unloaded')
 
     async def parse_steam_logs_for_executable(self, appid: str) -> dict:
         """Parse Steam console logs to find the exact executable path Steam uses"""
         try:
-            decky.logger.info(f"Parsing Steam logs for App ID: {appid}")
+            decky.logger.info(f'Parsing Steam logs for App ID: {appid}')
 
             # Check cache first
-            cache_key = f"steam_log_{appid}"
+            cache_key = f'steam_log_{appid}'
             if cache_key in self.executable_cache:
                 cached_result = self.executable_cache[cache_key]
                 # Check if cache is less than 1 hour old
                 if time.time() - cached_result.get('timestamp', 0) < 3600:
-                    decky.logger.info(f"Using cached result for {appid}")
+                    decky.logger.info(f'Using cached result for {appid}')
                     return cached_result
 
             # Steam log file locations
             log_files = [
-                "/home/deck/.steam/steam/logs/console-linux.txt",
-                "/home/deck/.steam/steam/logs/console_log.txt",
-                "/home/deck/.steam/steam/logs/console_log.previous.txt"
+                '/home/deck/.steam/steam/logs/console-linux.txt',
+                '/home/deck/.steam/steam/logs/console_log.txt',
+                '/home/deck/.steam/steam/logs/console_log.previous.txt',
             ]
 
             executable_path = None
@@ -90,7 +92,7 @@ class Plugin:
                 if not os.path.exists(log_file):
                     continue
 
-                decky.logger.info(f"Checking log file: {log_file}")
+                decky.logger.info(f'Checking log file: {log_file}')
 
                 try:
                     # Read the log file (check last 10000 lines for performance)
@@ -103,101 +105,107 @@ class Plugin:
                     for line in recent_lines:
                         # Pattern 1: Direct executable in launch command
                         # Example: AppId=501300 -- ... '/path/to/game.exe'
-                        if f"AppId={appid}" in line and ".exe" in line:
+                        if f'AppId={appid}' in line and '.exe' in line:
                             # Extract the executable path
                             exe_match = re.search(r"'([^']*\.exe)'", line)
                             if exe_match:
                                 potential_exe = exe_match.group(1)
                                 # Verify this is a real path and not a temp file
-                                if "/steamapps/common/" in potential_exe and os.path.exists(potential_exe):
+                                if '/steamapps/common/' in potential_exe and os.path.exists(
+                                    potential_exe
+                                ):
                                     executable_path = potential_exe
                                     launch_command = line.strip()
-                                    decky.logger.info(f"Found executable from logs: {executable_path}")
+                                    decky.logger.info(
+                                        f'Found executable from logs: {executable_path}'
+                                    )
                                     break
 
                         # Pattern 2: Game process added/updated logs
                         # Example: Game process added : AppID 501300 "command with exe path"
-                        if f"AppID {appid}" in line and (".exe" in line or "Game process" in line):
+                        if f'AppID {appid}' in line and ('.exe' in line or 'Game process' in line):
                             exe_match = re.search(r"'([^']*\.exe)'", line)
                             if not exe_match:
                                 # Try different quote patterns
                                 exe_match = re.search(r'"([^"]*\.exe)"', line)
                             if exe_match:
                                 potential_exe = exe_match.group(1)
-                                if "/steamapps/common/" in potential_exe and os.path.exists(potential_exe):
+                                if '/steamapps/common/' in potential_exe and os.path.exists(
+                                    potential_exe
+                                ):
                                     executable_path = potential_exe
                                     launch_command = line.strip()
-                                    decky.logger.info(f"Found executable from process log: {executable_path}")
+                                    decky.logger.info(
+                                        f'Found executable from process log: {executable_path}'
+                                    )
                                     break
 
                     if executable_path:
                         break
 
                 except Exception as e:
-                    decky.logger.error(f"Error reading log file {log_file}: {e!s}")
+                    decky.logger.error(f'Error reading log file {log_file}: {e!s}')
                     continue
 
             if executable_path:
                 # Cache the result
                 result = {
-                    "status": "success",
-                    "method": "steam_logs",
-                    "executable_path": executable_path,
-                    "directory_path": os.path.dirname(executable_path),
-                    "filename": os.path.basename(executable_path),
-                    "launch_command": launch_command,
-                    "timestamp": time.time()
+                    'status': 'success',
+                    'method': 'steam_logs',
+                    'executable_path': executable_path,
+                    'directory_path': os.path.dirname(executable_path),
+                    'filename': os.path.basename(executable_path),
+                    'launch_command': launch_command,
+                    'timestamp': time.time(),
                 }
                 self.executable_cache[cache_key] = result
 
                 return result
             else:
-                decky.logger.info(f"No executable found in logs for App ID: {appid}")
+                decky.logger.info(f'No executable found in logs for App ID: {appid}')
                 return {
-                    "status": "not_found",
-                    "method": "steam_logs",
-                    "message": "No executable path found in Steam logs"
+                    'status': 'not_found',
+                    'method': 'steam_logs',
+                    'message': 'No executable path found in Steam logs',
                 }
 
         except Exception as e:
-            decky.logger.error(f"Error parsing Steam logs: {e!s}")
-            return {
-                "status": "error",
-                "method": "steam_logs",
-                "message": str(e)
-            }
+            decky.logger.error(f'Error parsing Steam logs: {e!s}')
+            return {'status': 'error', 'method': 'steam_logs', 'message': str(e)}
 
     async def find_game_executable_enhanced(self, appid: str) -> dict:
         """Enhanced executable detection with simplified Linux game detection"""
         try:
-            decky.logger.info(f"Enhanced detection with simplified Linux check for App ID: {appid}")
+            decky.logger.info(f'Enhanced detection with simplified Linux check for App ID: {appid}')
 
             # Get the base game path using existing method
             try:
-                steam_root = Path(decky.HOME) / ".steam" / "steam"
-                library_file = steam_root / "steamapps" / "libraryfolders.vdf"
+                steam_root = Path(decky.HOME) / '.steam' / 'steam'
+                library_file = steam_root / 'steamapps' / 'libraryfolders.vdf'
 
                 if not library_file.exists():
-                    return {"status": "error", "message": "Steam library file not found"}
+                    return {'status': 'error', 'message': 'Steam library file not found'}
 
                 library_paths = []
-                with open(library_file, encoding="utf-8") as file:
+                with open(library_file, encoding='utf-8') as file:
                     for line in file:
                         if '"path"' in line:
-                            path = line.split('"path"')[1].strip().strip('"').replace("\\\\", "/")
+                            path = line.split('"path"')[1].strip().strip('"').replace('\\\\', '/')
                             library_paths.append(path)
 
                 base_game_path = None
                 game_name = None
                 for library_path in library_paths:
-                    manifest_path = Path(library_path) / "steamapps" / f"appmanifest_{appid}.acf"
+                    manifest_path = Path(library_path) / 'steamapps' / f'appmanifest_{appid}.acf'
                     if manifest_path.exists():
-                        with open(manifest_path, encoding="utf-8") as manifest:
+                        with open(manifest_path, encoding='utf-8') as manifest:
                             manifest_content = manifest.read()
                             for line in manifest_content.split('\n'):
                                 if '"installdir"' in line:
                                     install_dir = line.split('"installdir"')[1].strip().strip('"')
-                                    base_game_path = str(Path(library_path) / "steamapps" / "common" / install_dir)
+                                    base_game_path = str(
+                                        Path(library_path) / 'steamapps' / 'common' / install_dir
+                                    )
                                     game_name = install_dir
                                 elif '"name"' in line:
                                     game_title = line.split('"name"')[1].strip().strip('"')
@@ -206,39 +214,41 @@ class Plugin:
                         break
 
                 if not base_game_path:
-                    return {"status": "error", "message": f"Could not find installation directory for AppID: {appid}"}
+                    return {
+                        'status': 'error',
+                        'message': f'Could not find installation directory for AppID: {appid}',
+                    }
 
-                decky.logger.info(f"Base game path: {base_game_path}")
-                decky.logger.info(f"Game name from Steam: {game_name}")
+                decky.logger.info(f'Base game path: {base_game_path}')
+                decky.logger.info(f'Game name from Steam: {game_name}')
 
                 # Check appmanifest for Linux indicators
                 manifest_has_linux = False
                 for library_path in library_paths:
-                    manifest_path = Path(library_path) / "steamapps" / f"appmanifest_{appid}.acf"
+                    manifest_path = Path(library_path) / 'steamapps' / f'appmanifest_{appid}.acf'
                     if manifest_path.exists():
-                        with open(manifest_path, encoding="utf-8") as manifest:
+                        with open(manifest_path, encoding='utf-8') as manifest:
                             manifest_content = manifest.read().lower()
-                            if "linux" in manifest_content:
+                            if 'linux' in manifest_content:
                                 manifest_has_linux = True
                                 decky.logger.info("Found 'linux' in appmanifest")
                                 break
 
             except Exception as e:
-                return {"status": "error", "message": str(e)}
+                return {'status': 'error', 'message': str(e)}
 
             game_path_obj = Path(base_game_path)
             if not game_path_obj.exists():
-                return {"status": "error", "message": f"Game path not found: {base_game_path}"}
+                return {'status': 'error', 'message': f'Game path not found: {base_game_path}'}
 
             # Simplified Linux detection - only check for key indicators
-            linux_indicators = {
-                'so_files': [],
-                'sh_files': []
-            }
+            linux_indicators = {'so_files': [], 'sh_files': []}
 
             all_executables = []
 
-            decky.logger.info(f"Scanning directory tree for executables and Linux indicators: {base_game_path}")
+            decky.logger.info(
+                f'Scanning directory tree for executables and Linux indicators: {base_game_path}'
+            )
 
             # Single directory traversal
             for root, _dirs, files in os.walk(base_game_path):
@@ -253,16 +263,20 @@ class Plugin:
 
                     # Check for Windows executables
                     if file.lower().endswith('.exe'):
-                        all_executables.append({
-                            "path": file_path,
-                            "directory_path": os.path.dirname(file_path),
-                            "relative_path": rel_path,
-                            "filename": file,
-                            "size": file_size,
-                            "size_mb": round(file_size / (1024 * 1024), 1),
-                            "type": "windows_exe"
-                        })
-                        decky.logger.debug(f"Found Windows exe: {file} ({rel_path}) - {round(file_size / (1024 * 1024), 1)}MB")
+                        all_executables.append(
+                            {
+                                'path': file_path,
+                                'directory_path': os.path.dirname(file_path),
+                                'relative_path': rel_path,
+                                'filename': file,
+                                'size': file_size,
+                                'size_mb': round(file_size / (1024 * 1024), 1),
+                                'type': 'windows_exe',
+                            }
+                        )
+                        decky.logger.debug(
+                            f'Found Windows exe: {file} ({rel_path}) - {round(file_size / (1024 * 1024), 1)}MB'
+                        )
 
                     # Simplified Linux detection - only .so and .sh files
                     file_lower = file.lower()
@@ -270,24 +284,27 @@ class Plugin:
                     # Check for .so files
                     if file_lower.endswith('.so') or '.so.' in file_lower:
                         linux_indicators['so_files'].append(rel_path)
-                        decky.logger.debug(f"Found .so file: {rel_path}")
+                        decky.logger.debug(f'Found .so file: {rel_path}')
 
                     # Check for .sh files
                     elif file_lower.endswith('.sh'):
                         linux_indicators['sh_files'].append(rel_path)
-                        decky.logger.debug(f"Found .sh file: {rel_path}")
+                        decky.logger.debug(f'Found .sh file: {rel_path}')
 
             # Filter out utility executables from Windows list
             main_windows_executables = []
             for exe in all_executables:
-                if exe["type"] == "windows_exe":
-                    exe_name = exe["filename"].lower()
-                    if not any(skip in exe_name for skip in ["unins", "redist", "vcredist", "directx", "setup", "install"]):
+                if exe['type'] == 'windows_exe':
+                    exe_name = exe['filename'].lower()
+                    if not any(
+                        skip in exe_name
+                        for skip in ['unins', 'redist', 'vcredist', 'directx', 'setup', 'install']
+                    ):
                         main_windows_executables.append(exe)
 
             # Simplified Linux game determination
             is_linux_game = False
-            linux_confidence = "low"
+            linux_confidence = 'low'
             linux_reasons = []
 
             # Check for Linux indicators
@@ -296,95 +313,97 @@ class Plugin:
 
             if manifest_has_linux:
                 is_linux_game = True
-                linux_confidence = "high"
+                linux_confidence = 'high'
                 linux_reasons.append("Steam manifest contains 'linux'")
 
             if so_file_count >= 5:  # Multiple .so files is a strong indicator
                 is_linux_game = True
-                if linux_confidence != "high":
-                    linux_confidence = "medium"
-                linux_reasons.append(f"Found {so_file_count} shared library (.so) files")
+                if linux_confidence != 'high':
+                    linux_confidence = 'medium'
+                linux_reasons.append(f'Found {so_file_count} shared library (.so) files')
 
             if sh_file_count >= 2:  # Multiple shell scripts
                 is_linux_game = True
-                if linux_confidence == "low":
-                    linux_confidence = "medium"
-                linux_reasons.append(f"Found {sh_file_count} shell script (.sh) files")
+                if linux_confidence == 'low':
+                    linux_confidence = 'medium'
+                linux_reasons.append(f'Found {sh_file_count} shell script (.sh) files')
 
             # If no Windows executables and Linux indicators present
             if not main_windows_executables and (so_file_count > 0 or sh_file_count > 0):
                 is_linux_game = True
-                if linux_confidence == "low":
-                    linux_confidence = "medium"
-                linux_reasons.append("No Windows executables found, Linux files present")
+                if linux_confidence == 'low':
+                    linux_confidence = 'medium'
+                linux_reasons.append('No Windows executables found, Linux files present')
 
             # If it's determined to be a Linux game, return early with warning
-            if is_linux_game and linux_confidence in ["high", "medium"]:
+            if is_linux_game and linux_confidence in ['high', 'medium']:
                 return {
-                    "status": "linux_game_detected",
-                    "method": "enhanced_detection_with_simplified_linux_check",
-                    "is_linux_game": True,
-                    "linux_confidence": linux_confidence,
-                    "linux_reasons": linux_reasons,
-                    "linux_indicators": linux_indicators,
-                    "windows_executables_found": len(main_windows_executables),
-                    "message": "Linux version detected - ReShade requires Windows version through Proton",
-                    "details": {
-                        "game_path": base_game_path,
-                        "total_files_scanned": len(all_executables),
-                        "windows_exe_count": len(main_windows_executables),
-                        "so_files_count": so_file_count,
-                        "sh_files_count": sh_file_count
+                    'status': 'linux_game_detected',
+                    'method': 'enhanced_detection_with_simplified_linux_check',
+                    'is_linux_game': True,
+                    'linux_confidence': linux_confidence,
+                    'linux_reasons': linux_reasons,
+                    'linux_indicators': linux_indicators,
+                    'windows_executables_found': len(main_windows_executables),
+                    'message': 'Linux version detected - ReShade requires Windows version through Proton',
+                    'details': {
+                        'game_path': base_game_path,
+                        'total_files_scanned': len(all_executables),
+                        'windows_exe_count': len(main_windows_executables),
+                        'so_files_count': so_file_count,
+                        'sh_files_count': sh_file_count,
                     },
-                    "scan_summary": {
-                        "total_files_scanned": len(all_executables),
-                        "windows_executables": len(all_executables),
-                        "main_windows_executables": len(main_windows_executables),
-                        "so_files": so_file_count,
-                        "sh_files": sh_file_count,
-                        "linux_indicators_found": so_file_count + sh_file_count
-                    }
+                    'scan_summary': {
+                        'total_files_scanned': len(all_executables),
+                        'windows_executables': len(all_executables),
+                        'main_windows_executables': len(main_windows_executables),
+                        'so_files': so_file_count,
+                        'sh_files': sh_file_count,
+                        'linux_indicators_found': so_file_count + sh_file_count,
+                    },
                 }
 
             # Continue with Windows executable analysis if not a Linux game
             if not main_windows_executables:
                 return {
-                    "status": "error",
-                    "method": "enhanced_detection_with_simplified_linux_check",
-                    "is_linux_game": is_linux_game,
-                    "linux_confidence": linux_confidence,
-                    "message": f"No suitable Windows executables found in game directory: {base_game_path}",
-                    "details": {
-                        "total_executables_found": len(all_executables),
-                        "windows_exe_count": len(all_executables),
-                        "main_windows_exe_count": len(main_windows_executables),
-                        "so_files_count": so_file_count,
-                        "sh_files_count": sh_file_count
+                    'status': 'error',
+                    'method': 'enhanced_detection_with_simplified_linux_check',
+                    'is_linux_game': is_linux_game,
+                    'linux_confidence': linux_confidence,
+                    'message': f'No suitable Windows executables found in game directory: {base_game_path}',
+                    'details': {
+                        'total_executables_found': len(all_executables),
+                        'windows_exe_count': len(all_executables),
+                        'main_windows_exe_count': len(main_windows_executables),
+                        'so_files_count': so_file_count,
+                        'sh_files_count': sh_file_count,
                     },
-                    "scan_summary": {
-                        "total_files_scanned": len(all_executables),
-                        "windows_executables": len(all_executables),
-                        "main_windows_executables": len(main_windows_executables),
-                        "so_files": so_file_count,
-                        "sh_files": sh_file_count,
-                        "linux_indicators_found": so_file_count + sh_file_count
-                    }
+                    'scan_summary': {
+                        'total_files_scanned': len(all_executables),
+                        'windows_executables': len(all_executables),
+                        'main_windows_executables': len(main_windows_executables),
+                        'so_files': so_file_count,
+                        'sh_files': sh_file_count,
+                        'linux_indicators_found': so_file_count + sh_file_count,
+                    },
                 }
 
-            decky.logger.info(f"Found {len(main_windows_executables)} Windows executables for scoring")
+            decky.logger.info(
+                f'Found {len(main_windows_executables)} Windows executables for scoring'
+            )
 
             # ENHANCED SCORING for Windows executables (keeping existing logic)
             def score_executable(exe_info):
                 score = 50
-                filename = exe_info["filename"].lower()
+                filename = exe_info['filename'].lower()
                 filename_no_ext = os.path.splitext(filename)[0]
-                rel_path = exe_info["relative_path"].lower()
-                size_mb = exe_info["size_mb"]
+                rel_path = exe_info['relative_path'].lower()
+                size_mb = exe_info['size_mb']
 
-                decky.logger.debug(f"Scoring {filename} at {rel_path}")
+                decky.logger.debug(f'Scoring {filename} at {rel_path}')
 
                 # Enhanced game name matching with multiple normalization approaches
-                clean_game_name = re.sub(r'[^a-z0-9]', '', game_name.lower()) if game_name else ""
+                clean_game_name = re.sub(r'[^a-z0-9]', '', game_name.lower()) if game_name else ''
                 clean_filename = re.sub(r'[^a-z0-9]', '', filename_no_ext)
 
                 # Split into words for more flexible matching
@@ -397,19 +416,27 @@ class Plugin:
                 # Exact matches (highest priority)
                 if clean_filename == clean_game_name:
                     name_match_score += 60
-                    decky.logger.debug("  Exact name match: +60 (normalized names match exactly)")
+                    decky.logger.debug('  Exact name match: +60 (normalized names match exactly)')
 
                 # Substantial partial matches (high priority)
-                elif clean_game_name and (clean_game_name in clean_filename or clean_filename in clean_game_name):
+                elif clean_game_name and (
+                    clean_game_name in clean_filename or clean_filename in clean_game_name
+                ):
                     # Calculate how much of the string matches
                     match_ratio = max(
-                        len(clean_game_name) / len(clean_filename) if len(clean_filename) > 0 else 0,
-                        len(clean_filename) / len(clean_game_name) if len(clean_game_name) > 0 else 0
+                        len(clean_game_name) / len(clean_filename)
+                        if len(clean_filename) > 0
+                        else 0,
+                        len(clean_filename) / len(clean_game_name)
+                        if len(clean_game_name) > 0
+                        else 0,
                     )
                     # Scale the score based on how much of the string matches (max 45 points)
                     partial_score = min(45, int(match_ratio * 45))
                     name_match_score += partial_score
-                    decky.logger.debug(f"  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})")
+                    decky.logger.debug(
+                        f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})'
+                    )
 
                 # Word-level matches (medium priority)
                 else:
@@ -418,69 +445,80 @@ class Plugin:
 
                     if matching_words:
                         # Calculate match percentage relative to the source words
-                        match_percentage = len(matching_words) / len(game_name_words) if game_name_words else 0
-                        word_score = len(matching_words) * 8 * (1 + match_percentage)  # Scale based on percentage match
+                        match_percentage = (
+                            len(matching_words) / len(game_name_words) if game_name_words else 0
+                        )
+                        word_score = (
+                            len(matching_words) * 8 * (1 + match_percentage)
+                        )  # Scale based on percentage match
                         name_match_score += min(40, round(word_score))  # Cap at 40 points
-                        decky.logger.debug(f"  Word match: +{min(40, round(word_score))} ({matching_words})")
+                        decky.logger.debug(
+                            f'  Word match: +{min(40, round(word_score))} ({matching_words})'
+                        )
 
                 # Common game executable names bonus
-                if any(common in filename_no_ext.lower() for common in ["game", "main", "client", "app", "play"]):
+                if any(
+                    common in filename_no_ext.lower()
+                    for common in ['game', 'main', 'client', 'app', 'play']
+                ):
                     common_bonus = 15
                     name_match_score += common_bonus
-                    decky.logger.debug(f"  Common game exe name: +{common_bonus}")
+                    decky.logger.debug(f'  Common game exe name: +{common_bonus}')
 
                 # Add the name match score to the total score
                 score += name_match_score
 
                 # Size-based scoring (reduced weights)
                 size_score = 0
-                if size_mb > 50:      # Large games
+                if size_mb > 50:  # Large games
                     size_score = 10  # Reduced from 35
-                elif size_mb > 20:    # Medium games
-                    size_score = 8   # Reduced from 25
-                elif size_mb > 5:     # Small games
-                    size_score = 5   # Reduced from 15
-                elif size_mb > 1:     # Small but not tiny
-                    size_score = 2   # Reduced from 5
-                elif size_mb < 0.5:   # Very small files (likely utilities)
+                elif size_mb > 20:  # Medium games
+                    size_score = 8  # Reduced from 25
+                elif size_mb > 5:  # Small games
+                    size_score = 5  # Reduced from 15
+                elif size_mb > 1:  # Small but not tiny
+                    size_score = 2  # Reduced from 5
+                elif size_mb < 0.5:  # Very small files (likely utilities)
                     size_score = -20  # Keep this penalty to avoid tiny utility executables
 
                 score += size_score
-                decky.logger.debug(f"  Size score: +{size_score} ({size_mb} MB)")
+                decky.logger.debug(f'  Size score: +{size_score} ({size_mb} MB)')
 
                 # Path-based scoring (more moderate)
                 path_score = 0
-                if "binaries/win64" in rel_path or "binaries\\win64" in rel_path:    # Unreal Engine pattern
+                if (
+                    'binaries/win64' in rel_path or 'binaries\\win64' in rel_path
+                ):  # Unreal Engine pattern
                     path_score += 15  # Reduced from 25
-                elif "bin" in rel_path:             # Common bin directory
+                elif 'bin' in rel_path:  # Common bin directory
                     path_score += 10  # Reduced from 15
-                elif "game" in rel_path:            # Game subdirectory
-                    path_score += 8   # Reduced from 10
-                elif rel_path.count("/") == 0 and rel_path.count("\\") == 0:  # Root directory
-                    path_score += 5   # Reduced from 8
+                elif 'game' in rel_path:  # Game subdirectory
+                    path_score += 8  # Reduced from 10
+                elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
+                    path_score += 5  # Reduced from 8
 
                 score += path_score
-                decky.logger.debug(f"  Path score: +{path_score}")
+                decky.logger.debug(f'  Path score: +{path_score}')
 
                 # Special patterns from real data (more moderate)
                 special_score = 0
-                if "shipping" in filename:          # Unreal shipping builds
+                if 'shipping' in filename:  # Unreal shipping builds
                     special_score += 15  # Reduced from 20
-                elif "win64" in filename:           # 64-bit indicator
-                    special_score += 5   # Reduced from 8
-                elif "launcher" in filename:        # Launchers (lower score but don't exclude)
+                elif 'win64' in filename:  # 64-bit indicator
+                    special_score += 5  # Reduced from 8
+                elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
                     special_score -= 25  # Increased penalty from 15
 
                 score += special_score
                 if special_score != 0:
-                    decky.logger.debug(f"  Special pattern score: {special_score}")
+                    decky.logger.debug(f'  Special pattern score: {special_score}')
 
                 # Moderate penalty for deep nesting
-                path_depth = rel_path.count("/") + rel_path.count("\\")
+                path_depth = rel_path.count('/') + rel_path.count('\\')
                 if path_depth > 4:  # Increased threshold
                     depth_penalty = (path_depth - 4) * 3
                     score -= depth_penalty
-                    decky.logger.debug(f"  Deep nesting penalty: -{depth_penalty}")
+                    decky.logger.debug(f'  Deep nesting penalty: -{depth_penalty}')
 
                 # Cap score between 0 and 100
                 score = max(0, min(100, score))
@@ -488,7 +526,9 @@ class Plugin:
                 # Round to 1 decimal place for cleaner display
                 score = round(score, 1)
 
-                decky.logger.debug(f"  Final score for {filename}: {score} (name match: {name_match_score})")
+                decky.logger.debug(
+                    f'  Final score for {filename}: {score} (name match: {name_match_score})'
+                )
                 return score
 
             # Score all Windows executables
@@ -496,63 +536,62 @@ class Plugin:
             for exe_info in main_windows_executables:
                 score = score_executable(exe_info)
                 if score > 0:
-                    scored_executables.append({
-                        **exe_info,
-                        "score": score
-                    })
+                    scored_executables.append({**exe_info, 'score': score})
                 else:
-                    decky.logger.debug(f"Filtered out {exe_info['filename']} with score {score}")
+                    decky.logger.debug(f'Filtered out {exe_info["filename"]} with score {score}')
 
             if not scored_executables:
                 return {
-                    "status": "error",
-                    "method": "enhanced_detection_with_simplified_linux_check",
-                    "is_linux_game": is_linux_game,
-                    "message": "No suitable Windows executables found after scoring",
-                    "scan_summary": {
-                        "total_files_scanned": len(all_executables),
-                        "windows_executables": len(all_executables),
-                        "main_windows_executables": len(main_windows_executables),
-                        "so_files": so_file_count,
-                        "sh_files": sh_file_count,
-                        "linux_indicators_found": so_file_count + sh_file_count
-                    }
+                    'status': 'error',
+                    'method': 'enhanced_detection_with_simplified_linux_check',
+                    'is_linux_game': is_linux_game,
+                    'message': 'No suitable Windows executables found after scoring',
+                    'scan_summary': {
+                        'total_files_scanned': len(all_executables),
+                        'windows_executables': len(all_executables),
+                        'main_windows_executables': len(main_windows_executables),
+                        'so_files': so_file_count,
+                        'sh_files': sh_file_count,
+                        'linux_indicators_found': so_file_count + sh_file_count,
+                    },
                 }
 
             # Sort and get top results
-            scored_executables.sort(key=lambda x: x["score"], reverse=True)
+            scored_executables.sort(key=lambda x: x['score'], reverse=True)
             top_executables = scored_executables[:5]
             best_executable = top_executables[0]
 
-            decky.logger.info(f"Top executable: {best_executable['filename']} (score: {best_executable['score']})")
+            decky.logger.info(
+                f'Top executable: {best_executable["filename"]} (score: {best_executable["score"]})'
+            )
 
             return {
-                "status": "success",
-                "method": "enhanced_detection_with_simplified_linux_check",
-                "executable_path": best_executable["path"],
-                "directory_path": best_executable["directory_path"],
-                "filename": best_executable["filename"],
-                "all_executables": top_executables,
-                "confidence": "high" if best_executable["score"] > 70 else "medium",
-                "is_linux_game": is_linux_game,
-                "linux_confidence": linux_confidence,
-                "linux_reasons": linux_reasons if linux_reasons else None,
-                "scan_summary": {
-                    "total_files_scanned": len(all_executables),
-                    "windows_executables": len(all_executables),
-                    "main_windows_executables": len(main_windows_executables),
-                    "so_files": so_file_count,
-                    "sh_files": sh_file_count,
-                    "linux_indicators_found": so_file_count + sh_file_count
-                }
+                'status': 'success',
+                'method': 'enhanced_detection_with_simplified_linux_check',
+                'executable_path': best_executable['path'],
+                'directory_path': best_executable['directory_path'],
+                'filename': best_executable['filename'],
+                'all_executables': top_executables,
+                'confidence': 'high' if best_executable['score'] > 70 else 'medium',
+                'is_linux_game': is_linux_game,
+                'linux_confidence': linux_confidence,
+                'linux_reasons': linux_reasons if linux_reasons else None,
+                'scan_summary': {
+                    'total_files_scanned': len(all_executables),
+                    'windows_executables': len(all_executables),
+                    'main_windows_executables': len(main_windows_executables),
+                    'so_files': so_file_count,
+                    'sh_files': sh_file_count,
+                    'linux_indicators_found': so_file_count + sh_file_count,
+                },
             }
 
         except Exception as e:
-            decky.logger.error(f"Enhanced detection error: {e!s}")
+            decky.logger.error(f'Enhanced detection error: {e!s}')
             return {
-                "status": "error",
-                "method": "enhanced_detection_with_simplified_linux_check",
-                "message": str(e)
+                'status': 'error',
+                'method': 'enhanced_detection_with_simplified_linux_check',
+                'message': str(e),
             }
 
     async def find_game_executable_path(self, appid: str) -> dict:
@@ -560,7 +599,7 @@ class Plugin:
         Primary method that runs BOTH Steam logs and enhanced detection, returning both results
         """
         try:
-            decky.logger.info(f"Finding executable path for App ID: {appid}")
+            decky.logger.info(f'Finding executable path for App ID: {appid}')
 
             # Method 1: Steam console logs
             steam_logs_result = await self.parse_steam_logs_for_executable(appid)
@@ -569,59 +608,58 @@ class Plugin:
             enhanced_result = await self.find_game_executable_enhanced(appid)
 
             # Handle special case where enhanced detection found a Linux game
-            if enhanced_result.get("status") == "linux_game_detected":
+            if enhanced_result.get('status') == 'linux_game_detected':
                 # Return the Linux detection as the enhanced result
                 return {
-                    "status": "success",
-                    "steam_logs_result": steam_logs_result,
-                    "enhanced_detection_result": enhanced_result,
-                    "recommended_method": "enhanced_detection",  # Linux detection takes priority
-                    "linux_game_warning": True
+                    'status': 'success',
+                    'steam_logs_result': steam_logs_result,
+                    'enhanced_detection_result': enhanced_result,
+                    'recommended_method': 'enhanced_detection',  # Linux detection takes priority
+                    'linux_game_warning': True,
                 }
 
             # Determine recommended method for Windows games
-            recommended_method = "steam_logs"
-            if steam_logs_result["status"] != "success":
-                recommended_method = "enhanced_detection"
+            recommended_method = 'steam_logs'
+            if steam_logs_result['status'] != 'success':
+                recommended_method = 'enhanced_detection'
 
             return {
-                "status": "success",
-                "steam_logs_result": steam_logs_result,
-                "enhanced_detection_result": enhanced_result,
-                "recommended_method": recommended_method
+                'status': 'success',
+                'steam_logs_result': steam_logs_result,
+                'enhanced_detection_result': enhanced_result,
+                'recommended_method': recommended_method,
             }
 
         except Exception as e:
-            decky.logger.error(f"Error in find_game_executable_path: {e!s}")
-            return {
-                "status": "error",
-                "message": str(e)
-            }
+            decky.logger.error(f'Error in find_game_executable_path: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def find_heroic_game_executable_path(self, game_path: str, game_name: str) -> dict:
         """
         Find executable paths for a Heroic game, similar to Steam game detection
         """
         try:
-            decky.logger.info(f"Finding executable path for Heroic game: {game_name} at {game_path}")
+            decky.logger.info(
+                f'Finding executable path for Heroic game: {game_name} at {game_path}'
+            )
 
             # Check cache first
-            cache_key = f"heroic_{game_path}_{game_name}"
+            cache_key = f'heroic_{game_path}_{game_name}'
             if cache_key in self.executable_cache:
                 cached_result = self.executable_cache[cache_key]
                 # Check if cache is less than 1 hour old
                 if time.time() - cached_result.get('timestamp', 0) < 3600:
-                    decky.logger.info(f"Using cached result for {game_name}")
+                    decky.logger.info(f'Using cached result for {game_name}')
                     return cached_result
 
             # Verify game path exists
             if not os.path.exists(game_path):
-                return {"status": "error", "message": f"Game path not found: {game_path}"}
+                return {'status': 'error', 'message': f'Game path not found: {game_path}'}
 
             # Find all executables in the game directory
             all_executables = []
 
-            decky.logger.info(f"Walking directory tree starting from: {game_path}")
+            decky.logger.info(f'Walking directory tree starting from: {game_path}')
             for root, _dirs, files in os.walk(game_path):
                 for file in files:
                     if file.lower().endswith('.exe'):
@@ -630,42 +668,46 @@ class Plugin:
                             file_size = os.path.getsize(exe_path)
                             rel_path = os.path.relpath(exe_path, game_path)
 
-                            all_executables.append({
-                                "path": exe_path,
-                                "directory_path": os.path.dirname(exe_path),
-                                "relative_path": rel_path,
-                                "filename": file,
-                                "size": file_size,
-                                "size_mb": round(file_size / (1024 * 1024), 1)
-                            })
-                            decky.logger.debug(f"Found exe: {file} ({rel_path}) - {round(file_size / (1024 * 1024), 1)}MB")
+                            all_executables.append(
+                                {
+                                    'path': exe_path,
+                                    'directory_path': os.path.dirname(exe_path),
+                                    'relative_path': rel_path,
+                                    'filename': file,
+                                    'size': file_size,
+                                    'size_mb': round(file_size / (1024 * 1024), 1),
+                                }
+                            )
+                            decky.logger.debug(
+                                f'Found exe: {file} ({rel_path}) - {round(file_size / (1024 * 1024), 1)}MB'
+                            )
                         except Exception as e:
-                            decky.logger.warning(f"Error getting size for {exe_path}: {e!s}")
+                            decky.logger.warning(f'Error getting size for {exe_path}: {e!s}')
                             continue
 
             if not all_executables:
                 return {
-                    "status": "error",
-                    "method": "heroic_enhanced_detection",
-                    "message": f"No executables found in game directory: {game_path}"
+                    'status': 'error',
+                    'method': 'heroic_enhanced_detection',
+                    'message': f'No executables found in game directory: {game_path}',
                 }
 
-            decky.logger.info(f"Found {len(all_executables)} total executables")
+            decky.logger.info(f'Found {len(all_executables)} total executables')
 
             # Enhanced filtering based on discovered patterns
             def score_executable(exe_info):
                 score = 50  # Start with a base score
-                filename = exe_info["filename"].lower()
+                filename = exe_info['filename'].lower()
                 filename_no_ext = os.path.splitext(filename)[0]  # Remove extension
-                rel_path = exe_info["relative_path"].lower()
-                size_mb = exe_info["size_mb"]
+                rel_path = exe_info['relative_path'].lower()
+                size_mb = exe_info['size_mb']
 
-                decky.logger.debug(f"Scoring {filename} at {rel_path}")
+                decky.logger.debug(f'Scoring {filename} at {rel_path}')
 
                 # LESS aggressive utility filtering - only skip very obvious ones
-                utility_keywords = ["unins", "setup", "vcredist", "directx", "redist"]
+                utility_keywords = ['unins', 'setup', 'vcredist', 'directx', 'redist']
                 if any(skip in filename for skip in utility_keywords):
-                    decky.logger.debug(f"  Utility file detected: {filename}")
+                    decky.logger.debug(f'  Utility file detected: {filename}')
                     return 0
 
                 # Enhanced game name matching with multiple normalization approaches
@@ -684,7 +726,9 @@ class Plugin:
                 filename_words = re.findall(r'[a-z0-9]+', filename_no_ext)
 
                 # Log the normalized values for debugging
-                decky.logger.debug(f"  Normalized names - Dir: '{clean_dir_name}', Game: '{norm_game_name}', File: '{norm_filename}'")
+                decky.logger.debug(
+                    f"  Normalized names - Dir: '{clean_dir_name}', Game: '{norm_game_name}', File: '{norm_filename}'"
+                )
 
                 # 4. Calculate various types of matches
                 name_match_score = 0
@@ -692,37 +736,50 @@ class Plugin:
                 # Exact matches (highest priority)
                 if norm_filename in (norm_game_name, clean_dir_name):
                     name_match_score += 60
-                    decky.logger.debug("  Exact name match: +60 (normalized names match exactly)")
+                    decky.logger.debug('  Exact name match: +60 (normalized names match exactly)')
 
                 # Handle specific cases like "among us.exe" vs "amongus" folder
-                elif (norm_filename.replace(" ", "") == norm_game_name or
-                    norm_game_name.replace(" ", "") == norm_filename or
-                    norm_filename.replace(" ", "") == clean_dir_name or
-                    clean_dir_name.replace(" ", "") == norm_filename):
+                elif (
+                    norm_filename.replace(' ', '') == norm_game_name
+                    or norm_game_name.replace(' ', '') == norm_filename
+                    or norm_filename.replace(' ', '') == clean_dir_name
+                    or clean_dir_name.replace(' ', '') == norm_filename
+                ):
                     name_match_score += 55
-                    decky.logger.debug("  Space-normalized match: +55")
+                    decky.logger.debug('  Space-normalized match: +55')
 
                 # Substantial partial matches (high priority)
-                elif (norm_game_name in norm_filename or norm_filename in norm_game_name or
-                    clean_dir_name in norm_filename or norm_filename in clean_dir_name):
+                elif (
+                    norm_game_name in norm_filename
+                    or norm_filename in norm_game_name
+                    or clean_dir_name in norm_filename
+                    or norm_filename in clean_dir_name
+                ):
                     # Calculate how much of the string matches
                     match_ratio = max(
                         len(norm_game_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
                         len(norm_filename) / len(norm_game_name) if len(norm_game_name) > 0 else 0,
                         len(clean_dir_name) / len(norm_filename) if len(norm_filename) > 0 else 0,
-                        len(norm_filename) / len(clean_dir_name) if len(clean_dir_name) > 0 else 0
+                        len(norm_filename) / len(clean_dir_name) if len(clean_dir_name) > 0 else 0,
                     )
                     # Scale the score based on how much of the string matches (max 45 points)
                     partial_score = min(45, int(match_ratio * 45))
                     name_match_score += partial_score
-                    decky.logger.debug(f"  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})")
+                    decky.logger.debug(
+                        f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})'
+                    )
 
                     # Extra case for when folder has additional characters (like "DREDGEmKMzX" vs "DREDGE.exe")
-                    if (norm_filename in clean_dir_name and len(norm_filename) > 4 and
-                        len(norm_filename) >= len(clean_dir_name) * 0.5):
+                    if (
+                        norm_filename in clean_dir_name
+                        and len(norm_filename) > 4
+                        and len(norm_filename) >= len(clean_dir_name) * 0.5
+                    ):
                         extra_bonus = 15
                         name_match_score += extra_bonus
-                        decky.logger.debug(f"  Extra partial match bonus: +{extra_bonus} (likely main game exe)")
+                        decky.logger.debug(
+                            f'  Extra partial match bonus: +{extra_bonus} (likely main game exe)'
+                        )
 
                 # Word-level matches (medium priority)
                 else:
@@ -731,72 +788,87 @@ class Plugin:
                     matching_dir_words = set(dir_words).intersection(set(filename_words))
 
                     # Use the best match (dir or game name)
-                    best_matches = matching_game_words if len(matching_game_words) > len(matching_dir_words) else matching_dir_words
+                    best_matches = (
+                        matching_game_words
+                        if len(matching_game_words) > len(matching_dir_words)
+                        else matching_dir_words
+                    )
                     if best_matches:
                         # Calculate match percentage relative to the source words
-                        match_percentage = len(best_matches) / len(game_name_words) if game_name_words else 0
-                        word_score = len(best_matches) * 5.0 * (1 + match_percentage)  # Scale based on percentage match
+                        match_percentage = (
+                            len(best_matches) / len(game_name_words) if game_name_words else 0
+                        )
+                        word_score = (
+                            len(best_matches) * 5.0 * (1 + match_percentage)
+                        )  # Scale based on percentage match
                         name_match_score += min(40, round(word_score))  # Cap at 40 points
-                        decky.logger.debug(f"  Word match: +{min(40, round(word_score))} ({best_matches})")
+                        decky.logger.debug(
+                            f'  Word match: +{min(40, round(word_score))} ({best_matches})'
+                        )
 
                 # Common game executable names bonus
-                if any(common in filename_no_ext.lower() for common in ["game", "main", "client", "app", "play"]):
+                if any(
+                    common in filename_no_ext.lower()
+                    for common in ['game', 'main', 'client', 'app', 'play']
+                ):
                     common_bonus = 15
                     name_match_score += common_bonus
-                    decky.logger.debug(f"  Common game exe name: +{common_bonus}")
+                    decky.logger.debug(f'  Common game exe name: +{common_bonus}')
 
                 # Add the name match score to the total score
                 score += name_match_score
 
                 # Size-based scoring (reduced weights)
                 size_score = 0
-                if size_mb > 50:      # Large games
+                if size_mb > 50:  # Large games
                     size_score = 10  # Reduced from 35
-                elif size_mb > 20:    # Medium games
-                    size_score = 8   # Reduced from 25
-                elif size_mb > 5:     # Small games
-                    size_score = 5   # Reduced from 15
-                elif size_mb > 1:     # Small but not tiny
-                    size_score = 2   # Reduced from 5
-                elif size_mb < 0.5:   # Very small files (likely utilities)
+                elif size_mb > 20:  # Medium games
+                    size_score = 8  # Reduced from 25
+                elif size_mb > 5:  # Small games
+                    size_score = 5  # Reduced from 15
+                elif size_mb > 1:  # Small but not tiny
+                    size_score = 2  # Reduced from 5
+                elif size_mb < 0.5:  # Very small files (likely utilities)
                     size_score = -10  # Reduced from 20
 
                 score += size_score
-                decky.logger.debug(f"  Size score: +{size_score} ({size_mb} MB)")
+                decky.logger.debug(f'  Size score: +{size_score} ({size_mb} MB)')
 
                 # Path-based scoring
                 path_score = 0
-                if "binaries/win64" in rel_path or "binaries\\win64" in rel_path:    # Unreal Engine pattern
+                if (
+                    'binaries/win64' in rel_path or 'binaries\\win64' in rel_path
+                ):  # Unreal Engine pattern
                     path_score += 15  # Reduced from 25
-                elif "bin" in rel_path:             # Common bin directory
+                elif 'bin' in rel_path:  # Common bin directory
                     path_score += 10  # Reduced from 15
-                elif "game" in rel_path:            # Game subdirectory
-                    path_score += 8   # Reduced from 10
-                elif rel_path.count("/") == 0 and rel_path.count("\\") == 0:  # Root directory
-                    path_score += 5   # Reduced from 8
+                elif 'game' in rel_path:  # Game subdirectory
+                    path_score += 8  # Reduced from 10
+                elif rel_path.count('/') == 0 and rel_path.count('\\') == 0:  # Root directory
+                    path_score += 5  # Reduced from 8
 
                 score += path_score
-                decky.logger.debug(f"  Path score: +{path_score}")
+                decky.logger.debug(f'  Path score: +{path_score}')
 
                 # Special patterns scoring
                 special_score = 0
-                if "shipping" in filename:          # Unreal shipping builds
+                if 'shipping' in filename:  # Unreal shipping builds
                     special_score += 15  # Reduced from 20
-                elif "win64" in filename:           # 64-bit indicator
-                    special_score += 5   # Reduced from 8
-                elif "launcher" in filename:        # Launchers (lower score but don't exclude)
+                elif 'win64' in filename:  # 64-bit indicator
+                    special_score += 5  # Reduced from 8
+                elif 'launcher' in filename:  # Launchers (lower score but don't exclude)
                     special_score -= 25  # Increased penalty from 15
 
                 score += special_score
                 if special_score != 0:
-                    decky.logger.debug(f"  Special pattern score: {special_score}")
+                    decky.logger.debug(f'  Special pattern score: {special_score}')
 
                 # Moderate penalty for deep nesting
-                path_depth = rel_path.count("/") + rel_path.count("\\")
+                path_depth = rel_path.count('/') + rel_path.count('\\')
                 if path_depth > 4:  # Increased threshold
                     depth_penalty = (path_depth - 4) * 3
                     score -= depth_penalty
-                    decky.logger.debug(f"  Deep nesting penalty: -{depth_penalty}")
+                    decky.logger.debug(f'  Deep nesting penalty: -{depth_penalty}')
 
                 # Cap score between 0 and 100
                 score = max(0, min(100, score))
@@ -804,7 +876,9 @@ class Plugin:
                 # Round to 1 decimal place for cleaner display
                 score = round(score, 1)
 
-                decky.logger.debug(f"  Final score for {filename}: {score} (name match: {name_match_score})")
+                decky.logger.debug(
+                    f'  Final score for {filename}: {score} (name match: {name_match_score})'
+                )
                 return score
 
             # Score all executables
@@ -812,57 +886,52 @@ class Plugin:
             for exe_info in all_executables:
                 score = score_executable(exe_info)
                 if score > 0:
-                    scored_executables.append({
-                        **exe_info,
-                        "score": score
-                    })
+                    scored_executables.append({**exe_info, 'score': score})
                 else:
-                    decky.logger.debug(f"Filtered out {exe_info['filename']} with score {score}")
+                    decky.logger.debug(f'Filtered out {exe_info["filename"]} with score {score}')
 
             if not scored_executables:
                 # If we filtered everything out, include everything with any positive score
-                decky.logger.warning("All executables filtered out, using less restrictive filtering")
+                decky.logger.warning(
+                    'All executables filtered out, using less restrictive filtering'
+                )
                 for exe_info in all_executables:
                     score = score_executable(exe_info)
                     if score >= 0:
-                        scored_executables.append({
-                            **exe_info,
-                            "score": score
-                        })
+                        scored_executables.append({**exe_info, 'score': score})
 
             if not scored_executables:
                 # Last resort: include everything
-                decky.logger.warning("Still no executables, including all found")
+                decky.logger.warning('Still no executables, including all found')
                 for exe_info in all_executables:
-                    scored_executables.append({
-                        **exe_info,
-                        "score": score_executable(exe_info)
-                    })
+                    scored_executables.append({**exe_info, 'score': score_executable(exe_info)})
 
             # Sort by score (highest first) and take top 5
-            scored_executables.sort(key=lambda x: x["score"], reverse=True)
+            scored_executables.sort(key=lambda x: x['score'], reverse=True)
             top_executables = scored_executables[:5]
 
             best_executable = top_executables[0]
 
-            decky.logger.info(f"Total executables after filtering: {len(scored_executables)}")
-            decky.logger.info("Top 5 executables:")
+            decky.logger.info(f'Total executables after filtering: {len(scored_executables)}')
+            decky.logger.info('Top 5 executables:')
             for i, exe in enumerate(top_executables):
-                decky.logger.info(f"  {i+1}. {exe['filename']} (score: {exe['score']}) at {exe['relative_path']}")
+                decky.logger.info(
+                    f'  {i + 1}. {exe["filename"]} (score: {exe["score"]}) at {exe["relative_path"]}'
+                )
 
             result = {
-                "status": "success",
-                "heroic_enhanced_detection_result": {
-                    "status": "success",
-                    "method": "heroic_enhanced_detection",
-                    "executable_path": best_executable["path"],
-                    "directory_path": best_executable["directory_path"],
-                    "filename": best_executable["filename"],
-                    "all_executables": top_executables,
-                    "confidence": "high" if best_executable["score"] > 70 else "medium"
+                'status': 'success',
+                'heroic_enhanced_detection_result': {
+                    'status': 'success',
+                    'method': 'heroic_enhanced_detection',
+                    'executable_path': best_executable['path'],
+                    'directory_path': best_executable['directory_path'],
+                    'filename': best_executable['filename'],
+                    'all_executables': top_executables,
+                    'confidence': 'high' if best_executable['score'] > 70 else 'medium',
                 },
-                "recommended_method": "heroic_enhanced_detection",
-                "timestamp": time.time()
+                'recommended_method': 'heroic_enhanced_detection',
+                'timestamp': time.time(),
             }
 
             # Cache the result
@@ -871,17 +940,13 @@ class Plugin:
             return result
 
         except Exception as e:
-            decky.logger.error(f"Heroic executable detection error: {e!s}")
-            return {
-                "status": "error",
-                "method": "heroic_enhanced_detection",
-                "message": str(e)
-            }
+            decky.logger.error(f'Heroic executable detection error: {e!s}')
+            return {'status': 'error', 'method': 'heroic_enhanced_detection', 'message': str(e)}
 
     async def save_shader_preferences(self, selected_shaders: list) -> dict:
         """Save user's shader preferences to a file"""
         try:
-            preferences_file = os.path.join(self.main_path, "user_preferences.json")
+            preferences_file = os.path.join(self.main_path, 'user_preferences.json')
 
             # Load existing preferences to preserve other settings
             existing_preferences = {}
@@ -893,11 +958,13 @@ class Plugin:
                     pass  # If file is corrupted, start fresh
 
             # Update shader preferences while preserving other settings
-            existing_preferences.update({
-                "selected_shaders": selected_shaders,
-                "last_updated": int(time.time()),
-                "version": "1.1"
-            })
+            existing_preferences.update(
+                {
+                    'selected_shaders': selected_shaders,
+                    'last_updated': int(time.time()),
+                    'version': '1.1',
+                }
+            )
 
             # Ensure directory exists
             os.makedirs(self.main_path, exist_ok=True)
@@ -905,20 +972,20 @@ class Plugin:
             with open(preferences_file, 'w') as f:
                 json.dump(existing_preferences, f, indent=2)
 
-            decky.logger.info(f"Saved shader preferences: {selected_shaders}")
-            return {"status": "success", "message": "Shader preferences saved successfully"}
+            decky.logger.info(f'Saved shader preferences: {selected_shaders}')
+            return {'status': 'success', 'message': 'Shader preferences saved successfully'}
 
         except Exception as e:
-            decky.logger.error(f"Error saving shader preferences: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error saving shader preferences: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def load_shader_preferences(self) -> dict:
         """Load user's shader preferences from file"""
         try:
-            preferences_file = os.path.join(self.main_path, "user_preferences.json")
+            preferences_file = os.path.join(self.main_path, 'user_preferences.json')
 
             # Also check old file for migration
-            old_preferences_file = os.path.join(self.main_path, "shader_preferences.json")
+            old_preferences_file = os.path.join(self.main_path, 'shader_preferences.json')
 
             preferences = None
 
@@ -932,10 +999,10 @@ class Plugin:
                     old_prefs = json.load(f)
                     # Migrate to new format
                     preferences = {
-                        "selected_shaders": old_prefs.get("selected_shaders", []),
-                        "last_updated": old_prefs.get("last_updated", int(time.time())),
-                        "version": "1.1",
-                        "autohdr_enabled": False  # Default for migrated preferences
+                        'selected_shaders': old_prefs.get('selected_shaders', []),
+                        'last_updated': old_prefs.get('last_updated', int(time.time())),
+                        'version': '1.1',
+                        'autohdr_enabled': False,  # Default for migrated preferences
                     }
                     # Save in new format and remove old file
                     with open(preferences_file, 'w') as f:
@@ -944,53 +1011,57 @@ class Plugin:
                         os.remove(old_preferences_file)
 
             if not preferences:
-                return {"status": "success", "preferences": None, "message": "No preferences file found"}
+                return {
+                    'status': 'success',
+                    'preferences': None,
+                    'message': 'No preferences file found',
+                }
 
             # Validate the preferences structure
-            if "selected_shaders" not in preferences:
-                return {"status": "error", "message": "Invalid preferences file format"}
+            if 'selected_shaders' not in preferences:
+                return {'status': 'error', 'message': 'Invalid preferences file format'}
 
-            decky.logger.info(f"Loaded shader preferences: {preferences['selected_shaders']}")
+            decky.logger.info(f'Loaded shader preferences: {preferences["selected_shaders"]}')
             return {
-                "status": "success",
-                "preferences": preferences,
-                "selected_shaders": preferences["selected_shaders"]
+                'status': 'success',
+                'preferences': preferences,
+                'selected_shaders': preferences['selected_shaders'],
             }
 
         except Exception as e:
-            decky.logger.error(f"Error loading shader preferences: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error loading shader preferences: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def has_shader_preferences(self) -> dict:
         """Check if user has saved shader preferences"""
         try:
-            preferences_file = os.path.join(self.main_path, "user_preferences.json")
-            old_preferences_file = os.path.join(self.main_path, "shader_preferences.json")
+            preferences_file = os.path.join(self.main_path, 'user_preferences.json')
+            old_preferences_file = os.path.join(self.main_path, 'shader_preferences.json')
 
             exists = os.path.exists(preferences_file) or os.path.exists(old_preferences_file)
 
             if exists:
                 # Also load and return a summary
                 result = await self.load_shader_preferences()
-                if result["status"] == "success" and result["preferences"]:
-                    shader_count = len(result["selected_shaders"])
+                if result['status'] == 'success' and result['preferences']:
+                    shader_count = len(result['selected_shaders'])
                     return {
-                        "status": "success",
-                        "has_preferences": True,
-                        "shader_count": shader_count,
-                        "last_updated": result["preferences"].get("last_updated", 0)
+                        'status': 'success',
+                        'has_preferences': True,
+                        'shader_count': shader_count,
+                        'last_updated': result['preferences'].get('last_updated', 0),
                     }
 
-            return {"status": "success", "has_preferences": False}
+            return {'status': 'success', 'has_preferences': False}
 
         except Exception as e:
-            decky.logger.error(f"Error checking shader preferences: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error checking shader preferences: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def save_autohdr_preference(self, autohdr_enabled: bool) -> dict:
         """Save user's AutoHDR preference"""
         try:
-            preferences_file = os.path.join(self.main_path, "user_preferences.json")
+            preferences_file = os.path.join(self.main_path, 'user_preferences.json')
 
             # Load existing preferences to preserve other settings
             existing_preferences = {}
@@ -1002,15 +1073,17 @@ class Plugin:
                     pass  # If file is corrupted, start fresh
 
             # Update AutoHDR preference while preserving other settings
-            existing_preferences.update({
-                "autohdr_enabled": autohdr_enabled,
-                "last_updated": int(time.time()),
-                "version": "1.1"
-            })
+            existing_preferences.update(
+                {
+                    'autohdr_enabled': autohdr_enabled,
+                    'last_updated': int(time.time()),
+                    'version': '1.1',
+                }
+            )
 
             # Ensure selected_shaders exists if it doesn't
-            if "selected_shaders" not in existing_preferences:
-                existing_preferences["selected_shaders"] = []
+            if 'selected_shaders' not in existing_preferences:
+                existing_preferences['selected_shaders'] = []
 
             # Ensure directory exists
             os.makedirs(self.main_path, exist_ok=True)
@@ -1018,47 +1091,50 @@ class Plugin:
             with open(preferences_file, 'w') as f:
                 json.dump(existing_preferences, f, indent=2)
 
-            decky.logger.info(f"Saved AutoHDR preference: {autohdr_enabled}")
-            return {"status": "success", "message": "AutoHDR preference saved successfully"}
+            decky.logger.info(f'Saved AutoHDR preference: {autohdr_enabled}')
+            return {'status': 'success', 'message': 'AutoHDR preference saved successfully'}
 
         except Exception as e:
-            decky.logger.error(f"Error saving AutoHDR preference: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error saving AutoHDR preference: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def load_autohdr_preference(self) -> dict:
         """Load user's AutoHDR preference"""
         try:
-            preferences_file = os.path.join(self.main_path, "user_preferences.json")
+            preferences_file = os.path.join(self.main_path, 'user_preferences.json')
 
             if not os.path.exists(preferences_file):
-                return {"status": "success", "autohdr_enabled": False, "message": "No preferences file found"}
+                return {
+                    'status': 'success',
+                    'autohdr_enabled': False,
+                    'message': 'No preferences file found',
+                }
 
             with open(preferences_file) as f:
                 preferences = json.load(f)
 
-            autohdr_enabled = preferences.get("autohdr_enabled", False)
+            autohdr_enabled = preferences.get('autohdr_enabled', False)
 
-            decky.logger.info(f"Loaded AutoHDR preference: {autohdr_enabled}")
-            return {
-                "status": "success",
-                "autohdr_enabled": autohdr_enabled
-            }
+            decky.logger.info(f'Loaded AutoHDR preference: {autohdr_enabled}')
+            return {'status': 'success', 'autohdr_enabled': autohdr_enabled}
 
         except Exception as e:
-            decky.logger.error(f"Error loading AutoHDR preference: {e!s}")
-            return {"status": "error", "message": str(e), "autohdr_enabled": False}
+            decky.logger.error(f'Error loading AutoHDR preference: {e!s}')
+            return {'status': 'error', 'message': str(e), 'autohdr_enabled': False}
 
-    async def save_installed_configuration(self, with_addon: bool, version: str, with_autohdr: bool, selected_shaders: list) -> dict:
+    async def save_installed_configuration(
+        self, with_addon: bool, version: str, with_autohdr: bool, selected_shaders: list
+    ) -> dict:
         """Save the configuration that was actually installed"""
         try:
-            config_file = os.path.join(self.main_path, "installed_config.json")
+            config_file = os.path.join(self.main_path, 'installed_config.json')
 
             installed_config = {
-                "with_addon": with_addon,
-                "version": version,
-                "with_autohdr": with_autohdr,
-                "selected_shaders": selected_shaders or [],
-                "installed_at": int(time.time())
+                'with_addon': with_addon,
+                'version': version,
+                'with_autohdr': with_autohdr,
+                'selected_shaders': selected_shaders or [],
+                'installed_at': int(time.time()),
             }
 
             os.makedirs(self.main_path, exist_ok=True)
@@ -1066,43 +1142,43 @@ class Plugin:
             with open(config_file, 'w') as f:
                 json.dump(installed_config, f, indent=2)
 
-            decky.logger.info(f"Saved installed configuration: {installed_config}")
-            return {"status": "success"}
+            decky.logger.info(f'Saved installed configuration: {installed_config}')
+            return {'status': 'success'}
 
         except Exception as e:
-            decky.logger.error(f"Error saving installed configuration: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error saving installed configuration: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def load_installed_configuration(self) -> dict:
         """Load the configuration that was actually installed"""
         try:
-            config_file = os.path.join(self.main_path, "installed_config.json")
+            config_file = os.path.join(self.main_path, 'installed_config.json')
 
             if not os.path.exists(config_file):
-                return {"status": "success", "config": None}
+                return {'status': 'success', 'config': None}
 
             with open(config_file) as f:
                 config = json.load(f)
 
-            return {"status": "success", "config": config}
+            return {'status': 'success', 'config': config}
 
         except Exception as e:
-            decky.logger.error(f"Error loading installed configuration: {e!s}")
-            return {"status": "error", "message": str(e), "config": None}
+            decky.logger.error(f'Error loading installed configuration: {e!s}')
+            return {'status': 'error', 'message': str(e), 'config': None}
 
     async def clear_installed_configuration(self) -> dict:
         """Clear the installed configuration (called on uninstall)"""
         try:
-            config_file = os.path.join(self.main_path, "installed_config.json")
+            config_file = os.path.join(self.main_path, 'installed_config.json')
 
             if os.path.exists(config_file):
                 os.remove(config_file)
 
-            return {"status": "success"}
+            return {'status': 'success'}
 
         except Exception as e:
-            decky.logger.error(f"Error clearing installed configuration: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error clearing installed configuration: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def get_available_shaders(self) -> dict:
         """Get list of available shader packages for selection"""
@@ -1111,8 +1187,8 @@ class Plugin:
             plugin_dir = Path(decky.DECKY_PLUGIN_DIR)
 
             # Check both possible locations for bin directory
-            defaults_bin = plugin_dir / "defaults" / "bin"
-            assets_bin = plugin_dir / "bin"
+            defaults_bin = plugin_dir / 'defaults' / 'bin'
+            assets_bin = plugin_dir / 'bin'
 
             bin_path = None
             if defaults_bin.exists():
@@ -1120,91 +1196,91 @@ class Plugin:
             elif assets_bin.exists():
                 bin_path = assets_bin
             else:
-                return {"status": "error", "message": "Bin directory not found"}
+                return {'status': 'error', 'message': 'Bin directory not found'}
 
             # Define available shader packages with descriptions
             shader_packages = [
                 {
-                    "id": "reshade_shaders",
-                    "name": "ReShade Community Shaders",
-                    "description": "Official ReShade community shader collection",
-                    "file": "reshade_shaders.tar.gz",
-                    "size_mb": "~15MB",
-                    "enabled": True
+                    'id': 'reshade_shaders',
+                    'name': 'ReShade Community Shaders',
+                    'description': 'Official ReShade community shader collection',
+                    'file': 'reshade_shaders.tar.gz',
+                    'size_mb': '~15MB',
+                    'enabled': True,
                 },
                 {
-                    "id": "sweetfx_shaders",
-                    "name": "SweetFX Shaders",
-                    "description": "Popular SweetFX shader effects collection",
-                    "file": "sweetfx_shaders.tar.gz",
-                    "size_mb": "~8MB",
-                    "enabled": True
+                    'id': 'sweetfx_shaders',
+                    'name': 'SweetFX Shaders',
+                    'description': 'Popular SweetFX shader effects collection',
+                    'file': 'sweetfx_shaders.tar.gz',
+                    'size_mb': '~8MB',
+                    'enabled': True,
                 },
                 {
-                    "id": "martymc_shaders",
-                    "name": "MartyMcFly's RT Shaders",
-                    "description": "High-quality ray tracing and lighting effects",
-                    "file": "martymc_shaders.tar.gz",
-                    "size_mb": "~12MB",
-                    "enabled": True
+                    'id': 'martymc_shaders',
+                    'name': "MartyMcFly's RT Shaders",
+                    'description': 'High-quality ray tracing and lighting effects',
+                    'file': 'martymc_shaders.tar.gz',
+                    'size_mb': '~12MB',
+                    'enabled': True,
                 },
                 {
-                    "id": "astrayfx_shaders",
-                    "name": "AstrayFX Shaders",
-                    "description": "Performance-focused shader collection",
-                    "file": "astrayfx_shaders.tar.gz",
-                    "size_mb": "~5MB",
-                    "enabled": True
+                    'id': 'astrayfx_shaders',
+                    'name': 'AstrayFX Shaders',
+                    'description': 'Performance-focused shader collection',
+                    'file': 'astrayfx_shaders.tar.gz',
+                    'size_mb': '~5MB',
+                    'enabled': True,
                 },
                 {
-                    "id": "prod80_shaders",
-                    "name": "Prod80's Shaders",
-                    "description": "Professional color grading and enhancement shaders",
-                    "file": "prod80_shaders.tar.gz",
-                    "size_mb": "~6MB",
-                    "enabled": True
+                    'id': 'prod80_shaders',
+                    'name': "Prod80's Shaders",
+                    'description': 'Professional color grading and enhancement shaders',
+                    'file': 'prod80_shaders.tar.gz',
+                    'size_mb': '~6MB',
+                    'enabled': True,
                 },
                 {
-                    "id": "retroarch_shaders",
-                    "name": "RetroArch Shaders",
-                    "description": "Retro gaming and CRT emulation effects",
-                    "file": "retroarch_shaders.tar.gz",
-                    "size_mb": "~10MB",
-                    "enabled": True
-                }
+                    'id': 'retroarch_shaders',
+                    'name': 'RetroArch Shaders',
+                    'description': 'Retro gaming and CRT emulation effects',
+                    'file': 'retroarch_shaders.tar.gz',
+                    'size_mb': '~10MB',
+                    'enabled': True,
+                },
             ]
 
             # Check which shader packages actually exist
             available_shaders = []
             for shader in shader_packages:
-                shader_file = bin_path / shader["file"]
+                shader_file = bin_path / shader['file']
                 if shader_file.exists():
                     # Get actual file size
                     file_size = shader_file.stat().st_size
                     size_mb = round(file_size / (1024 * 1024), 1)
-                    shader["size_mb"] = f"{size_mb}MB"
+                    shader['size_mb'] = f'{size_mb}MB'
                     available_shaders.append(shader)
                 else:
-                    decky.logger.warning(f"Shader package not found: {shader_file}")
+                    decky.logger.warning(f'Shader package not found: {shader_file}')
 
             return {
-                "status": "success",
-                "shaders": available_shaders,
-                "total_count": len(available_shaders)
+                'status': 'success',
+                'shaders': available_shaders,
+                'total_count': len(available_shaders),
             }
 
         except Exception as e:
-            decky.logger.error(f"Error getting available shaders: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error getting available shaders: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def detect_steam_deck_model(self) -> dict:
         """Detect Steam Deck model (OLED vs LCD) using board name"""
         try:
-            decky.logger.info("Detecting Steam Deck model...")
+            decky.logger.info('Detecting Steam Deck model...')
 
             # First check if we can read system info at all
             is_steam_deck = False
-            product_name = ""
+            product_name = ''
 
             try:
                 with open('/sys/devices/virtual/dmi/id/product_name') as f:
@@ -1212,56 +1288,53 @@ class Plugin:
                 decky.logger.info(f"DMI Product name: '{product_name}'")
 
                 # More flexible Steam Deck detection
-                if any(term in product_name.lower() for term in ["steam deck", "steamdeck", "jupiter", "galileo"]):
+                if any(
+                    term in product_name.lower()
+                    for term in ['steam deck', 'steamdeck', 'jupiter', 'galileo']
+                ):
                     is_steam_deck = True
-                    decky.logger.info("Confirmed this is a Steam Deck")
+                    decky.logger.info('Confirmed this is a Steam Deck')
                 else:
-                    decky.logger.warning(f"Product name '{product_name}' doesn't indicate Steam Deck")
+                    decky.logger.warning(
+                        f"Product name '{product_name}' doesn't indicate Steam Deck"
+                    )
             except (FileNotFoundError, PermissionError) as e:
-                decky.logger.warning(f"Could not read DMI product name: {e}")
+                decky.logger.warning(f'Could not read DMI product name: {e}')
 
             # If we can't confirm it's a Steam Deck through product name,
             # let's assume it is and try board detection anyway
             if not is_steam_deck:
-                decky.logger.info("Could not confirm Steam Deck via product name, proceeding with board detection")
+                decky.logger.info(
+                    'Could not confirm Steam Deck via product name, proceeding with board detection'
+                )
 
             # Check board name - most reliable method for Steam Deck OLED vs LCD
-            board_name = ""
+            board_name = ''
             try:
                 with open('/sys/devices/virtual/dmi/id/board_name') as f:
                     board_name = f.read().strip()
                 decky.logger.info(f"DMI Board name: '{board_name}'")
 
                 # Check for OLED (Galileo)
-                if "Galileo" in board_name:
-                    decky.logger.info("Detected Steam Deck OLED (Galileo)")
-                    return {
-                        "status": "success",
-                        "model": "OLED",
-                        "is_oled": True
-                    }
+                if 'Galileo' in board_name:
+                    decky.logger.info('Detected Steam Deck OLED (Galileo)')
+                    return {'status': 'success', 'model': 'OLED', 'is_oled': True}
                 # Check for LCD (Jupiter)
-                elif "Jupiter" in board_name:
-                    decky.logger.info("Detected Steam Deck LCD (Jupiter)")
-                    return {
-                        "status": "success",
-                        "model": "LCD",
-                        "is_oled": False
-                    }
+                elif 'Jupiter' in board_name:
+                    decky.logger.info('Detected Steam Deck LCD (Jupiter)')
+                    return {'status': 'success', 'model': 'LCD', 'is_oled': False}
                 else:
                     decky.logger.warning(f"Unknown board name: '{board_name}'")
 
                     # If we confirmed it's a Steam Deck but unknown board, default to LCD
                     if is_steam_deck:
-                        decky.logger.info("Confirmed Steam Deck but unknown board, defaulting to LCD")
-                        return {
-                            "status": "success",
-                            "model": "LCD",
-                            "is_oled": False
-                        }
+                        decky.logger.info(
+                            'Confirmed Steam Deck but unknown board, defaulting to LCD'
+                        )
+                        return {'status': 'success', 'model': 'LCD', 'is_oled': False}
 
             except (FileNotFoundError, PermissionError) as e:
-                decky.logger.warning(f"Could not read DMI board name: {e}")
+                decky.logger.warning(f'Could not read DMI board name: {e}')
 
             # Additional fallback checks for Steam Deck detection
             try:
@@ -1270,74 +1343,69 @@ class Plugin:
                     vendor = f.read().strip()
                 decky.logger.info(f"System vendor: '{vendor}'")
 
-                if "Valve" in vendor:
+                if 'Valve' in vendor:
                     is_steam_deck = True
-                    decky.logger.info("Confirmed Steam Deck via vendor")
+                    decky.logger.info('Confirmed Steam Deck via vendor')
             except (FileNotFoundError, PermissionError) as e:
-                decky.logger.debug(f"Could not read sys_vendor: {e}")
+                decky.logger.debug(f'Could not read sys_vendor: {e}')
 
             # Final decision logic
             if is_steam_deck:
                 # We know it's a Steam Deck but couldn't determine the model
-                decky.logger.info("Confirmed Steam Deck, but model detection failed - defaulting to LCD")
-                return {
-                    "status": "success",
-                    "model": "LCD",
-                    "is_oled": False
-                }
+                decky.logger.info(
+                    'Confirmed Steam Deck, but model detection failed - defaulting to LCD'
+                )
+                return {'status': 'success', 'model': 'LCD', 'is_oled': False}
             else:
                 # We couldn't confirm this is a Steam Deck
-                decky.logger.info("Could not confirm this is a Steam Deck")
-                return {
-                    "status": "success",
-                    "model": "Not Steam Deck",
-                    "is_oled": False
-                }
+                decky.logger.info('Could not confirm this is a Steam Deck')
+                return {'status': 'success', 'model': 'Not Steam Deck', 'is_oled': False}
 
         except Exception as e:
-            decky.logger.error(f"Error detecting Steam Deck model: {e!s}")
-            return {
-                "status": "error",
-                "message": str(e),
-                "model": "Unknown",
-                "is_oled": False
-            }
+            decky.logger.error(f'Error detecting Steam Deck model: {e!s}')
+            return {'status': 'error', 'message': str(e), 'model': 'Unknown', 'is_oled': False}
 
     async def check_reshade_path(self) -> dict:
-        path = Path(os.path.expanduser("~/.local/share/reshade"))
-        marker_file = path / ".installed"
-        addon_marker = path / ".installed_addon"
+        path = Path(os.path.expanduser('~/.local/share/reshade'))
+        marker_file = path / '.installed'
+        addon_marker = path / '.installed_addon'
 
         # Check version information
-        version_info = {"version": "unknown", "addon": False}
+        version_info = {'version': 'unknown', 'addon': False}
         if marker_file.exists() or addon_marker.exists():
             try:
-                version_file = path / "reshade" / "LVERS"
+                version_file = path / 'reshade' / 'LVERS'
                 if version_file.exists():
                     with open(version_file) as f:
                         version_content = f.read().strip()
                         # Extract version number (e.g., "6.7.3_Addon" -> "6.7.3")
                         version_match = re.search(r'(\d+\.\d+\.\d+)', version_content)
                         if version_match:
-                            version_info["version"] = version_match.group(1)
-                        version_info["addon"] = "addon" in version_content.lower()
+                            version_info['version'] = version_match.group(1)
+                        version_info['addon'] = 'addon' in version_content.lower()
             except Exception as e:
-                decky.logger.error(f"Error reading version info: {e!s}")
+                decky.logger.error(f'Error reading version info: {e!s}')
 
         return {
-            "exists": marker_file.exists() or addon_marker.exists(),
-            "is_addon": addon_marker.exists(),
-            "version_info": version_info
+            'exists': marker_file.exists() or addon_marker.exists(),
+            'is_addon': addon_marker.exists(),
+            'version_info': version_info,
         }
 
-    async def run_install_reshade(self, with_addon: bool = False, version: str = "6.7.3", with_autohdr: bool = False, selected_shaders: list | None = None) -> dict:
+    async def run_install_reshade(
+        self,
+        with_addon: bool = False,
+        version: str = '6.7.3',
+        with_autohdr: bool = False,
+        selected_shaders: list | None = None,
+    ) -> dict:
         try:
             assets_dir = self._get_assets_dir()
-            script_path = assets_dir / "reshade-install.sh"
+            script_path = assets_dir / 'reshade-install.sh'
 
             if not script_path.exists():
-                decky.logger.error(f"Install script not found: {script_path}")
-                return {"status": "error", "message": "Install script not found"}
+                decky.logger.error(f'Install script not found: {script_path}')
+                return {'status': 'error', 'message': 'Install script not found'}
 
             # Create a new environment dictionary for this installation
             install_env = self.environment.copy()
@@ -1352,72 +1420,76 @@ class Plugin:
                 # Convert selected shaders list to comma-separated string
                 selected_shader_ids = ','.join(selected_shaders) if selected_shaders else ''
                 install_env['SELECTED_SHADERS'] = selected_shader_ids
-                decky.logger.info(f"Selected shader packages: {selected_shader_ids}")
+                decky.logger.info(f'Selected shader packages: {selected_shader_ids}')
             else:
                 # Install all shaders (default behavior)
                 install_env['SELECTED_SHADERS'] = 'all'
 
             # Add other necessary environment variables
-            install_env.update({
-                'LD_LIBRARY_PATH': '/usr/lib',
-                'XDG_DATA_HOME': os.path.expandvars('$HOME/.local/share')
-            })
+            install_env.update(
+                {
+                    'LD_LIBRARY_PATH': '/usr/lib',
+                    'XDG_DATA_HOME': os.path.expandvars('$HOME/.local/share'),
+                }
+            )
 
-            install_description = f"Installing ReShade {version}"
+            install_description = f'Installing ReShade {version}'
             if with_addon:
-                install_description += " with addon support"
+                install_description += ' with addon support'
             if with_autohdr:
-                install_description += " and AutoHDR components"
+                install_description += ' and AutoHDR components'
             if selected_shaders and selected_shaders != ['all']:
-                install_description += f" with {len(selected_shaders)} shader packages"
+                install_description += f' with {len(selected_shaders)} shader packages'
 
             decky.logger.info(install_description)
-            decky.logger.info(f"Environment: {install_env}")
+            decky.logger.info(f'Environment: {install_env}')
 
             # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
             clean_env = {**os.environ, **install_env}
-            clean_env["LD_LIBRARY_PATH"] = ""
+            clean_env['LD_LIBRARY_PATH'] = ''
 
             process = subprocess.run(
-                ["/bin/bash", str(script_path)],
+                ['/bin/bash', str(script_path)],
                 cwd=str(assets_dir),
                 env=clean_env,
                 capture_output=True,
                 text=True,
-                timeout=300
+                timeout=300,
             )
 
-            decky.logger.info(f"Install output:\n{process.stdout}")
+            decky.logger.info(f'Install output:\n{process.stdout}')
             if process.stderr:
-                decky.logger.error(f"Install errors:\n{process.stderr}")
+                decky.logger.error(f'Install errors:\n{process.stderr}')
 
             if process.returncode != 0:
-                return {"status": "error", "message": process.stderr}
+                return {'status': 'error', 'message': process.stderr}
 
             # Create appropriate installation marker
             if with_addon:
-                marker_file = Path(self.main_path) / ".installed_addon"
+                marker_file = Path(self.main_path) / '.installed_addon'
                 # Remove non-addon marker if it exists
-                normal_marker = Path(self.main_path) / ".installed"
+                normal_marker = Path(self.main_path) / '.installed'
                 if normal_marker.exists():
                     normal_marker.unlink()
             else:
-                marker_file = Path(self.main_path) / ".installed"
+                marker_file = Path(self.main_path) / '.installed'
                 # Remove addon marker if it exists
-                addon_marker = Path(self.main_path) / ".installed_addon"
+                addon_marker = Path(self.main_path) / '.installed_addon'
                 if addon_marker.exists():
                     addon_marker.unlink()
 
             marker_file.touch()
 
             # Save the installed configuration
-            await self.save_installed_configuration(with_addon, version, with_autohdr, selected_shaders)
+            await self.save_installed_configuration(
+                with_addon, version, with_autohdr, selected_shaders
+            )
 
             # Clear executable cache since new installation might affect detection
             self.executable_cache.clear()
 
             # Create success message
-            version_display = f"ReShade {version.title()}"
+            version_display = f'ReShade {version.title()}'
             if with_addon:
                 version_display += ' (with Addon Support)'
             if with_autohdr:
@@ -1425,37 +1497,37 @@ class Plugin:
             if selected_shaders and selected_shaders != ['all']:
                 version_display += f' with {len(selected_shaders)} shader packages'
 
-            return {"status": "success", "output": f"{version_display} installed successfully!"}
+            return {'status': 'success', 'output': f'{version_display} installed successfully!'}
         except Exception as e:
-            decky.logger.error(f"Install error: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Install error: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def run_uninstall_reshade(self) -> dict:
         try:
             assets_dir = self._get_assets_dir()
-            script_path = assets_dir / "reshade-uninstall.sh"
+            script_path = assets_dir / 'reshade-uninstall.sh'
 
             if not script_path.exists():
-                return {"status": "error", "message": "Uninstall script not found"}
+                return {'status': 'error', 'message': 'Uninstall script not found'}
 
             # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
             clean_env = {**os.environ, **self.environment}
-            clean_env["LD_LIBRARY_PATH"] = ""
+            clean_env['LD_LIBRARY_PATH'] = ''
 
             process = subprocess.run(
-                ["/bin/bash", str(script_path)],
+                ['/bin/bash', str(script_path)],
                 cwd=str(assets_dir),
                 env=clean_env,
                 capture_output=True,
-                text=True
+                text=True,
             )
 
             if process.returncode != 0:
-                return {"status": "error", "message": process.stderr}
+                return {'status': 'error', 'message': process.stderr}
 
             # Remove installation markers
-            marker_file = Path(self.main_path) / ".installed"
-            addon_marker = Path(self.main_path) / ".installed_addon"
+            marker_file = Path(self.main_path) / '.installed'
+            addon_marker = Path(self.main_path) / '.installed_addon'
             if marker_file.exists():
                 marker_file.unlink()
             if addon_marker.exists():
@@ -1465,187 +1537,232 @@ class Plugin:
             await self.clear_installed_configuration()
             self.executable_cache.clear()
 
-            return {"status": "success", "output": "ReShade uninstalled"}
+            return {'status': 'success', 'output': 'ReShade uninstalled'}
         except Exception as e:
             decky.logger.error(str(e))
-            return {"status": "error", "message": str(e)}
+            return {'status': 'error', 'message': str(e)}
 
-    async def manage_game_reshade(self, appid: str, action: str, dll_override: str = "dxgi", vulkan_mode: str = "", selected_executable_path: str = "") -> dict:
+    async def manage_game_reshade(
+        self,
+        appid: str,
+        action: str,
+        dll_override: str = 'dxgi',
+        vulkan_mode: str = '',
+        selected_executable_path: str = '',
+    ) -> dict:
         try:
             assets_dir = self._get_assets_dir()
-            script_path = assets_dir / "reshade-game-manager.sh"
+            script_path = assets_dir / 'reshade-game-manager.sh'
 
             # Track if user selected a specific executable path
-            using_user_selected_path = bool(selected_executable_path and os.path.exists(selected_executable_path))
+            using_user_selected_path = bool(
+                selected_executable_path and os.path.exists(selected_executable_path)
+            )
 
             try:
                 # Use selected executable path if provided, otherwise use detection
                 if using_user_selected_path:
                     game_path = os.path.dirname(selected_executable_path)
-                    decky.logger.info(f"Using user-selected executable path: {selected_executable_path}")
-                    decky.logger.info(f"Installing ReShade to directory: {game_path}")
-                elif action == "install":
+                    decky.logger.info(
+                        f'Using user-selected executable path: {selected_executable_path}'
+                    )
+                    decky.logger.info(f'Installing ReShade to directory: {game_path}')
+                elif action == 'install':
                     # Get the base game installation path (not executable-specific directory)
                     game_path = self._find_game_path(appid)
-                    decky.logger.info(f"Using base game path for Bash detection: {game_path}")
+                    decky.logger.info(f'Using base game path for Bash detection: {game_path}')
                 else:
                     # For uninstall, we still need to find where ReShade was installed
                     # Try to use our detection first, then fall back to base path
                     try:
                         exe_result = await self.find_game_executable_path(appid)
-                        if (exe_result["status"] == "success" and
-                            exe_result.get("steam_logs_result", {}).get("status") == "success"):
-                            game_path = os.path.dirname(exe_result["steam_logs_result"]["executable_path"])
-                            decky.logger.info(f"Using detected executable directory for uninstall: {game_path}")
-                        elif (exe_result["status"] == "success" and
-                              exe_result.get("enhanced_detection_result", {}).get("status") == "success"):
-                            game_path = os.path.dirname(exe_result["enhanced_detection_result"]["executable_path"])
-                            decky.logger.info(f"Using enhanced detection directory for uninstall: {game_path}")
+                        if (
+                            exe_result['status'] == 'success'
+                            and exe_result.get('steam_logs_result', {}).get('status') == 'success'
+                        ):
+                            game_path = os.path.dirname(
+                                exe_result['steam_logs_result']['executable_path']
+                            )
+                            decky.logger.info(
+                                f'Using detected executable directory for uninstall: {game_path}'
+                            )
+                        elif (
+                            exe_result['status'] == 'success'
+                            and exe_result.get('enhanced_detection_result', {}).get('status')
+                            == 'success'
+                        ):
+                            game_path = os.path.dirname(
+                                exe_result['enhanced_detection_result']['executable_path']
+                            )
+                            decky.logger.info(
+                                f'Using enhanced detection directory for uninstall: {game_path}'
+                            )
                         else:
                             game_path = self._find_game_path(appid)
-                            decky.logger.info(f"Using base game path for uninstall: {game_path}")
+                            decky.logger.info(f'Using base game path for uninstall: {game_path}')
                     except Exception:
                         game_path = self._find_game_path(appid)
-                        decky.logger.info(f"Using base game path for uninstall (fallback): {game_path}")
+                        decky.logger.info(
+                            f'Using base game path for uninstall (fallback): {game_path}'
+                        )
 
-                decky.logger.info(f"Final game path: {game_path}")
+                decky.logger.info(f'Final game path: {game_path}')
             except ValueError as e:
-                return {"status": "error", "message": str(e)}
+                return {'status': 'error', 'message': str(e)}
 
             # Build command - if user selected a specific path, don't pass appid to prevent bash script from overriding
-            cmd = ["/bin/bash", str(script_path), action, game_path, dll_override]
+            cmd = ['/bin/bash', str(script_path), action, game_path, dll_override]
             if vulkan_mode:
-                cmd.extend([vulkan_mode, os.path.expanduser(f"~/.local/share/Steam/steamapps/compatdata/{appid}"), appid])
+                cmd.extend(
+                    [
+                        vulkan_mode,
+                        os.path.expanduser(f'~/.local/share/Steam/steamapps/compatdata/{appid}'),
+                        appid,
+                    ]
+                )
             else:
                 # For non-Vulkan mode, add empty placeholders for vulkan_mode and wineprefix
                 if using_user_selected_path:
                     # Don't pass appid when using user-selected path to prevent bash script from overriding
-                    cmd.extend(["", "", ""])
-                    decky.logger.info("Not passing App ID to bash script to prevent path override")
+                    cmd.extend(['', '', ''])
+                    decky.logger.info('Not passing App ID to bash script to prevent path override')
                 else:
                     # Pass appid for automatic detection
-                    cmd.extend(["", "", appid])
+                    cmd.extend(['', '', appid])
 
-            decky.logger.info(f"Executing command: {' '.join(cmd)}")
+            decky.logger.info(f'Executing command: {" ".join(cmd)}')
 
             # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
             clean_env = {**os.environ, **self.environment}
-            clean_env["LD_LIBRARY_PATH"] = ""
+            clean_env['LD_LIBRARY_PATH'] = ''
 
             process = subprocess.run(
-                cmd,
-                cwd=str(assets_dir),
-                env=clean_env,
-                capture_output=True,
-                text=True
+                cmd, cwd=str(assets_dir), env=clean_env, capture_output=True, text=True
             )
 
-            decky.logger.info(f"Script output: {process.stdout}")
+            decky.logger.info(f'Script output: {process.stdout}')
             if process.stderr:
-                decky.logger.error(f"Script errors: {process.stderr}")
+                decky.logger.error(f'Script errors: {process.stderr}')
 
             if process.returncode != 0:
-                return {"status": "error", "message": process.stderr}
+                return {'status': 'error', 'message': process.stderr}
 
-            return {"status": "success", "output": process.stdout}
+            return {'status': 'success', 'output': process.stdout}
         except Exception as e:
             decky.logger.error(str(e))
-            return {"status": "error", "message": str(e)}
+            return {'status': 'error', 'message': str(e)}
 
     async def list_installed_games(self) -> dict:
         try:
-            steam_root = Path(decky.HOME) / ".steam" / "steam"
-            library_file = steam_root / "steamapps" / "libraryfolders.vdf"
+            steam_root = Path(decky.HOME) / '.steam' / 'steam'
+            library_file = steam_root / 'steamapps' / 'libraryfolders.vdf'
 
             if not library_file.exists():
-                return {"status": "error", "message": "libraryfolders.vdf not found"}
+                return {'status': 'error', 'message': 'libraryfolders.vdf not found'}
 
             library_paths = []
-            with open(library_file, encoding="utf-8") as file:
+            with open(library_file, encoding='utf-8') as file:
                 for line in file:
                     if '"path"' in line:
-                        path = line.split('"path"')[1].strip().strip('"').replace("\\\\", "/")
+                        path = line.split('"path"')[1].strip().strip('"').replace('\\\\', '/')
                         library_paths.append(path)
 
             games = []
             for library_path in library_paths:
-                steamapps_path = Path(library_path) / "steamapps"
+                steamapps_path = Path(library_path) / 'steamapps'
                 if not steamapps_path.exists():
                     continue
 
-                for appmanifest in steamapps_path.glob("appmanifest_*.acf"):
-                    with open(appmanifest, encoding="utf-8") as file:
-                        game_info = {"appid": None, "name": None}
+                for appmanifest in steamapps_path.glob('appmanifest_*.acf'):
+                    with open(appmanifest, encoding='utf-8') as file:
+                        game_info = {'appid': None, 'name': None}
                         for line in file:
                             if '"appid"' in line:
-                                game_info["appid"] = line.split('"appid"')[1].strip().strip('"')
+                                game_info['appid'] = line.split('"appid"')[1].strip().strip('"')
                             if '"name"' in line:
-                                game_info["name"] = line.split('"name"')[1].strip().strip('"')
+                                game_info['name'] = line.split('"name"')[1].strip().strip('"')
 
-                        if game_info["appid"] and game_info["name"]:
+                        if game_info['appid'] and game_info['name']:
                             games.append(game_info)
 
             # Filter out system components and redistributables that shouldn't be modded with ReShade
-            filtered_games = [g for g in games if not any(exclude in g["name"] for exclude in [
-                "Proton",
-                "Steam Linux Runtime",
-                "Steamworks Common Redistributables",
-                "DirectX",
-                "Visual C++",
-                "Microsoft Visual C++",
-                ".NET Framework",
-                "OpenXR"
-            ])]
+            filtered_games = [
+                g
+                for g in games
+                if not any(
+                    exclude in g['name']
+                    for exclude in [
+                        'Proton',
+                        'Steam Linux Runtime',
+                        'Steamworks Common Redistributables',
+                        'DirectX',
+                        'Visual C++',
+                        'Microsoft Visual C++',
+                        '.NET Framework',
+                        'OpenXR',
+                    ]
+                )
+            ]
 
-            return {"status": "success", "games": filtered_games}
+            return {'status': 'success', 'games': filtered_games}
 
         except Exception as e:
             decky.logger.error(str(e))
-            return {"status": "error", "message": str(e)}
+            return {'status': 'error', 'message': str(e)}
 
     async def find_heroic_games(self) -> dict:
         """Find games installed through Heroic Launcher using the config file"""
         try:
             # Read the Heroic config file to get the default install path
-            heroic_config_path = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/config.json")
+            heroic_config_path = os.path.expanduser(
+                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/config.json'
+            )
 
             if not os.path.exists(heroic_config_path):
-                return {"status": "error", "message": "Heroic config file not found"}
+                return {'status': 'error', 'message': 'Heroic config file not found'}
 
             with open(heroic_config_path, encoding='utf-8') as f:
                 heroic_config = json.load(f)
 
             # Get the install path from config
-            default_install_path = heroic_config.get("settings", {}).get("defaultInstallPath")
+            default_install_path = heroic_config.get('settings', {}).get('defaultInstallPath')
             if not default_install_path:
-                default_install_path = os.path.expanduser("~/Games/Heroic")  # Fallback
+                default_install_path = os.path.expanduser('~/Games/Heroic')  # Fallback
 
-            decky.logger.info(f"Heroic games install path: {default_install_path}")
+            decky.logger.info(f'Heroic games install path: {default_install_path}')
 
             # Get the list of recent games for quick reference
-            recent_games = heroic_config.get("games", {}).get("recent", [])
-            recent_games_map = {game.get("title"): game.get("appName") for game in recent_games if game.get("title") and game.get("appName")}
+            recent_games = heroic_config.get('games', {}).get('recent', [])
+            recent_games_map = {
+                game.get('title'): game.get('appName')
+                for game in recent_games
+                if game.get('title') and game.get('appName')
+            }
 
             # Find all game directories in the install path
             games = []
             if os.path.exists(default_install_path):
                 for game_dir in os.listdir(default_install_path):
                     game_path = os.path.join(default_install_path, game_dir)
-                    if os.path.isdir(game_path) and game_dir.lower() not in ["prefixes", "temp", "legendary", "gog", "state", "logs"]:
+                    if os.path.isdir(game_path) and game_dir.lower() not in [
+                        'prefixes',
+                        'temp',
+                        'legendary',
+                        'gog',
+                        'state',
+                        'logs',
+                    ]:
                         # This is likely a game directory
-                        game_info = {
-                            "name": game_dir,
-                            "path": game_path
-                        }
+                        game_info = {'name': game_dir, 'path': game_path}
 
                         # Check if this game is in the recent games list
                         if game_dir in recent_games_map:
-                            game_info["app_id"] = recent_games_map[game_dir]
+                            game_info['app_id'] = recent_games_map[game_dir]
 
                         # Try to find a better name from appinfo.json if it exists
                         appinfo_paths = [
-                            os.path.join(game_path, "appinfo.json"),
-                            os.path.join(game_path, ".egstore", "appinfo.json")
+                            os.path.join(game_path, 'appinfo.json'),
+                            os.path.join(game_path, '.egstore', 'appinfo.json'),
                         ]
 
                         for appinfo_path in appinfo_paths:
@@ -1653,89 +1770,108 @@ class Plugin:
                                 try:
                                     with open(appinfo_path, encoding='utf-8') as f:
                                         appinfo = json.load(f)
-                                        if "DisplayName" in appinfo:
-                                            game_info["name"] = appinfo["DisplayName"]
-                                        elif "AppName" in appinfo:
-                                            game_info["name"] = appinfo["AppName"]
-                                        if "AppId" in appinfo:
-                                            game_info["app_id"] = str(appinfo["AppId"])
+                                        if 'DisplayName' in appinfo:
+                                            game_info['name'] = appinfo['DisplayName']
+                                        elif 'AppName' in appinfo:
+                                            game_info['name'] = appinfo['AppName']
+                                        if 'AppId' in appinfo:
+                                            game_info['app_id'] = str(appinfo['AppId'])
                                         break
                                 except Exception as e:
-                                    decky.logger.error(f"Error reading appinfo.json for {game_dir}: {e!s}")
+                                    decky.logger.error(
+                                        f'Error reading appinfo.json for {game_dir}: {e!s}'
+                                    )
 
                         # Find and cache the config file information if available
-                        if "app_id" in game_info:
+                        if 'app_id' in game_info:
                             # Check if there's a direct config file match
-                            games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+                            games_config_dir = os.path.expanduser(
+                                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+                            )
                             for config_file in os.listdir(games_config_dir):
-                                if config_file.endswith(".json"):
+                                if config_file.endswith('.json'):
                                     config_file_path = os.path.join(games_config_dir, config_file)
                                     try:
                                         with open(config_file_path, encoding='utf-8') as f:
                                             config_data = json.load(f)
                                             # Check if app_id is a key in this config file
-                                            if game_info["app_id"] in config_data:
-                                                game_info["config_file"] = config_file
-                                                game_info["config_key"] = game_info["app_id"]
+                                            if game_info['app_id'] in config_data:
+                                                game_info['config_file'] = config_file
+                                                game_info['config_key'] = game_info['app_id']
                                                 break
                                     except Exception as e:
-                                        decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                                        decky.logger.error(
+                                            f'Error reading config file {config_file}: {e!s}'
+                                        )
 
                         games.append(game_info)
 
             # Sort games alphabetically by name
-            games.sort(key=lambda g: g["name"].lower())
+            games.sort(key=lambda g: g['name'].lower())
 
-            return {"status": "success", "games": games}
+            return {'status': 'success', 'games': games}
         except Exception as e:
-            decky.logger.error(f"Error finding Heroic games: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error finding Heroic games: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def find_heroic_game_config(self, game_path: str, game_name: str) -> dict:
         """
         Find the config file and key for a Heroic game using the config.json file
         """
         try:
-            decky.logger.info(f"Finding config for Heroic game: {game_name} at {game_path}")
+            decky.logger.info(f'Finding config for Heroic game: {game_name} at {game_path}')
 
             # Normalize game name for more flexible matching
-            normalized_game_name = game_name.lower().replace(" ", "").replace("-", "").replace("_", "")
+            normalized_game_name = (
+                game_name.lower().replace(' ', '').replace('-', '').replace('_', '')
+            )
             normalized_game_path = os.path.normpath(game_path)
             base_folder_name = os.path.basename(normalized_game_path).lower()
 
-            decky.logger.info(f"Normalized game name: {normalized_game_name}")
-            decky.logger.info(f"Base folder name: {base_folder_name}")
+            decky.logger.info(f'Normalized game name: {normalized_game_name}')
+            decky.logger.info(f'Base folder name: {base_folder_name}')
 
             # First, try to read the Heroic config file
-            heroic_config_path = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/config.json")
+            heroic_config_path = os.path.expanduser(
+                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/store/config.json'
+            )
             if os.path.exists(heroic_config_path):
                 with open(heroic_config_path, encoding='utf-8') as f:
                     heroic_config = json.load(f)
 
                 # Get the list of recent games
-                recent_games = heroic_config.get("games", {}).get("recent", [])
+                recent_games = heroic_config.get('games', {}).get('recent', [])
 
                 # Look for a match by title with flexible matching
                 for game in recent_games:
-                    game_title = game.get("title", "")
-                    normalized_title = game_title.lower().replace(" ", "").replace("-", "").replace("_", "")
+                    game_title = game.get('title', '')
+                    normalized_title = (
+                        game_title.lower().replace(' ', '').replace('-', '').replace('_', '')
+                    )
 
                     # Try multiple matching approaches
-                    if (game.get("title") == game_name or  # Exact match
-                        normalized_title == normalized_game_name or  # Normalized match
-                        normalized_game_name in normalized_title or  # Normalized game name is in title
-                        normalized_title in normalized_game_name or  # Normalized title is in game name
-                        base_folder_name.startswith(normalized_title) or  # Folder starts with title
-                        normalized_title.startswith(base_folder_name)):  # Title starts with folder
-
-                        app_name = game.get("appName")
+                    if (
+                        game.get('title') == game_name  # Exact match
+                        or normalized_title == normalized_game_name  # Normalized match
+                        or normalized_game_name
+                        in normalized_title  # Normalized game name is in title
+                        or normalized_title
+                        in normalized_game_name  # Normalized title is in game name
+                        or base_folder_name.startswith(normalized_title)  # Folder starts with title
+                        or normalized_title.startswith(base_folder_name)
+                    ):  # Title starts with folder
+                        app_name = game.get('appName')
                         if app_name:
-                            decky.logger.info(f"Found appName in config.json for '{game_title}': {app_name}")
+                            decky.logger.info(
+                                f"Found appName in config.json for '{game_title}': {app_name}"
+                            )
 
                             # Now look for this appName in the GamesConfig directory
-                            games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+                            games_config_dir = os.path.expanduser(
+                                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+                            )
                             for config_file in os.listdir(games_config_dir):
-                                if not config_file.endswith(".json"):
+                                if not config_file.endswith('.json'):
                                     continue
 
                                 config_file_path = os.path.join(games_config_dir, config_file)
@@ -1744,21 +1880,27 @@ class Plugin:
                                         config_data = json.load(f)
 
                                         if app_name in config_data:
-                                            decky.logger.info(f"Found config file: {config_file}, key: {app_name}")
+                                            decky.logger.info(
+                                                f'Found config file: {config_file}, key: {app_name}'
+                                            )
                                             return {
-                                                "status": "success",
-                                                "config_file": config_file,
-                                                "config_key": app_name
+                                                'status': 'success',
+                                                'config_file': config_file,
+                                                'config_key': app_name,
                                             }
                                 except Exception as e:
-                                    decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                                    decky.logger.error(
+                                        f'Error reading config file {config_file}: {e!s}'
+                                    )
 
                 # If direct matching failed, try checking winePrefix paths in all config files
-                decky.logger.info("Trying to match using winePrefix paths...")
-                games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+                decky.logger.info('Trying to match using winePrefix paths...')
+                games_config_dir = os.path.expanduser(
+                    '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+                )
 
                 for config_file in os.listdir(games_config_dir):
-                    if not config_file.endswith(".json"):
+                    if not config_file.endswith('.json'):
                         continue
 
                     config_file_path = os.path.join(games_config_dir, config_file)
@@ -1769,50 +1911,75 @@ class Plugin:
                             # Check each game config
                             for app_key, app_config in config_data.items():
                                 # Check winePrefix path
-                                wine_prefix = app_config.get("winePrefix", "")
+                                wine_prefix = app_config.get('winePrefix', '')
                                 if wine_prefix:
                                     # Get both last part and parent part of path for more chances to match
                                     prefix_parts = wine_prefix.rstrip('/').split('/')
                                     last_part = prefix_parts[-1].lower()
-                                    parent_part = prefix_parts[-2].lower() if len(prefix_parts) > 1 else ""
+                                    parent_part = (
+                                        prefix_parts[-2].lower() if len(prefix_parts) > 1 else ''
+                                    )
 
                                     # Normalize for matching
-                                    last_part_norm = last_part.replace(" ", "").replace("-", "").replace("_", "")
-                                    parent_part_norm = parent_part.replace(" ", "").replace("-", "").replace("_", "")
+                                    last_part_norm = (
+                                        last_part.replace(' ', '').replace('-', '').replace('_', '')
+                                    )
+                                    parent_part_norm = (
+                                        parent_part.replace(' ', '')
+                                        .replace('-', '')
+                                        .replace('_', '')
+                                    )
 
                                     # Enhanced matching for Wine prefix components
-                                    if (last_part.lower() == game_name.lower() or
-                                        last_part_norm == normalized_game_name or
-                                        normalized_game_name in last_part_norm or
-                                        last_part_norm in normalized_game_name or
-                                        base_folder_name.startswith(last_part_norm) or
-                                        last_part_norm.startswith(base_folder_name) or
+                                    if (
+                                        last_part.lower() == game_name.lower()
+                                        or last_part_norm == normalized_game_name
+                                        or normalized_game_name in last_part_norm
+                                        or last_part_norm in normalized_game_name
+                                        or base_folder_name.startswith(last_part_norm)
+                                        or last_part_norm.startswith(base_folder_name)
+                                        or
                                         # Also check parent directory if it's not a common prefix folder
-                                        (parent_part and parent_part not in ["prefixes", "wine", "pfx"] and (
-                                            parent_part.lower() == game_name.lower() or
-                                            parent_part_norm == normalized_game_name or
-                                            normalized_game_name in parent_part_norm or
-                                            parent_part_norm in normalized_game_name or
-                                            base_folder_name.startswith(parent_part_norm) or
-                                            parent_part_norm.startswith(base_folder_name)))):
+                                        (
+                                            parent_part
+                                            and parent_part not in ['prefixes', 'wine', 'pfx']
+                                            and (
+                                                parent_part.lower() == game_name.lower()
+                                                or parent_part_norm == normalized_game_name
+                                                or normalized_game_name in parent_part_norm
+                                                or parent_part_norm in normalized_game_name
+                                                or base_folder_name.startswith(parent_part_norm)
+                                                or parent_part_norm.startswith(base_folder_name)
+                                            )
+                                        )
+                                    ):
+                                        match_type = (
+                                            'last_part'
+                                            if (
+                                                last_part.lower() == game_name.lower()
+                                                or last_part_norm == normalized_game_name
+                                                or normalized_game_name in last_part_norm
+                                                or last_part_norm in normalized_game_name
+                                            )
+                                            else 'parent_part'
+                                        )
 
-                                        match_type = "last_part" if (last_part.lower() == game_name.lower() or
-                                                                    last_part_norm == normalized_game_name or
-                                                                    normalized_game_name in last_part_norm or
-                                                                    last_part_norm in normalized_game_name) else "parent_part"
-
-                                        decky.logger.info(f"Found match via winePrefix {match_type}: {wine_prefix}")
-                                        decky.logger.info(f"Config file: {config_file}, key: {app_key}")
+                                        decky.logger.info(
+                                            f'Found match via winePrefix {match_type}: {wine_prefix}'
+                                        )
+                                        decky.logger.info(
+                                            f'Config file: {config_file}, key: {app_key}'
+                                        )
                                         return {
-                                            "status": "success",
-                                            "config_file": config_file,
-                                            "config_key": app_key
+                                            'status': 'success',
+                                            'config_file': config_file,
+                                            'config_key': app_key,
                                         }
                     except Exception as e:
-                        decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                        decky.logger.error(f'Error reading config file {config_file}: {e!s}')
 
             # Improved executable name matching
-            decky.logger.info("Trying enhanced matching using executable names...")
+            decky.logger.info('Trying enhanced matching using executable names...')
 
             # Find the executable directory
             exe_dir = self._find_heroic_game_executable_directory(game_path)
@@ -1823,37 +1990,50 @@ class Plugin:
             exe_files = []
             try:
                 for file in os.listdir(exe_dir):
-                    if file.lower().endswith(".exe") and not any(skip in file.lower() for skip in
-                                                            ["unins", "launcher", "crash", "setup", "config", "redist"]):
+                    if file.lower().endswith('.exe') and not any(
+                        skip in file.lower()
+                        for skip in ['unins', 'launcher', 'crash', 'setup', 'config', 'redist']
+                    ):
                         exe_files.append(file)
 
                 # Try additional subdirectories if no EXEs found in main directory
                 if not exe_files:
-                    for subdir in ["bin", "binaries", "game", "win64", "x64"]:
+                    for subdir in ['bin', 'binaries', 'game', 'win64', 'x64']:
                         subdir_path = os.path.join(exe_dir, subdir)
                         if os.path.exists(subdir_path) and os.path.isdir(subdir_path):
                             for file in os.listdir(subdir_path):
-                                if file.lower().endswith(".exe") and not any(skip in file.lower() for skip in
-                                                                        ["unins", "launcher", "crash", "setup", "config", "redist"]):
+                                if file.lower().endswith('.exe') and not any(
+                                    skip in file.lower()
+                                    for skip in [
+                                        'unins',
+                                        'launcher',
+                                        'crash',
+                                        'setup',
+                                        'config',
+                                        'redist',
+                                    ]
+                                ):
                                     exe_files.append(file)
-                                    decky.logger.info(f"Found exe in subdirectory {subdir}: {file}")
+                                    decky.logger.info(f'Found exe in subdirectory {subdir}: {file}')
             except Exception as e:
-                decky.logger.error(f"Error listing executable directory: {e!s}")
+                decky.logger.error(f'Error listing executable directory: {e!s}')
 
             if exe_files:
                 # Use all executable names for matching, not just the first one
-                games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+                games_config_dir = os.path.expanduser(
+                    '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+                )
 
                 for exe_file in exe_files:
                     # Get name without .exe extension
                     exe_name = os.path.splitext(exe_file)[0].lower()
-                    exe_name_norm = exe_name.replace(" ", "").replace("-", "").replace("_", "")
+                    exe_name_norm = exe_name.replace(' ', '').replace('-', '').replace('_', '')
 
-                    decky.logger.info(f"Trying to match using executable: {exe_name}")
+                    decky.logger.info(f'Trying to match using executable: {exe_name}')
 
                     # Check all config files for matches
                     for config_file in os.listdir(games_config_dir):
-                        if not config_file.endswith(".json"):
+                        if not config_file.endswith('.json'):
                             continue
 
                         config_file_path = os.path.join(games_config_dir, config_file)
@@ -1864,41 +2044,65 @@ class Plugin:
                                 # Check all games in this config
                                 for app_key, app_config in config_data.items():
                                     # Get game info and any other relevant fields that might contain the game name
-                                    game_info = app_config.get("game", {})
-                                    config_title = game_info.get("title", "").lower()
-                                    config_title_norm = config_title.replace(" ", "").replace("-", "").replace("_", "")
+                                    game_info = app_config.get('game', {})
+                                    config_title = game_info.get('title', '').lower()
+                                    config_title_norm = (
+                                        config_title.replace(' ', '')
+                                        .replace('-', '')
+                                        .replace('_', '')
+                                    )
 
                                     # Also check the app config directly for game name
-                                    app_title = app_config.get("title", "").lower()
-                                    app_title_norm = app_title.replace(" ", "").replace("-", "").replace("_", "")
+                                    app_title = app_config.get('title', '').lower()
+                                    app_title_norm = (
+                                        app_title.replace(' ', '').replace('-', '').replace('_', '')
+                                    )
 
                                     # Enhanced matching for executable names
-                                    if (exe_name == config_title.lower() or
-                                        exe_name_norm in (config_title_norm, app_title_norm) or
-                                        exe_name == app_title.lower() or
-                                        exe_name_norm in config_title_norm or
-                                        exe_name_norm in app_title_norm or
-                                        config_title_norm in exe_name_norm or
-                                        app_title_norm in exe_name_norm):
+                                    if (
+                                        exe_name == config_title.lower()
+                                        or exe_name_norm in (config_title_norm, app_title_norm)
+                                        or exe_name == app_title.lower()
+                                        or exe_name_norm in config_title_norm
+                                        or exe_name_norm in app_title_norm
+                                        or config_title_norm in exe_name_norm
+                                        or app_title_norm in exe_name_norm
+                                    ):
+                                        match_source = (
+                                            'game_info'
+                                            if exe_name_norm in config_title_norm
+                                            else 'app_config'
+                                        )
+                                        match_type = (
+                                            'exact'
+                                            if (
+                                                exe_name == config_title.lower()
+                                                or exe_name == app_title.lower()
+                                            )
+                                            else 'partial'
+                                        )
 
-                                        match_source = "game_info" if exe_name_norm in config_title_norm else "app_config"
-                                        match_type = "exact" if (exe_name == config_title.lower() or exe_name == app_title.lower()) else "partial"
-
-                                        decky.logger.info(f"Found match via executable name: {exe_name} matches '{config_title or app_title}' ({match_type} match from {match_source})")
-                                        decky.logger.info(f"Config file: {config_file}, key: {app_key}")
+                                        decky.logger.info(
+                                            f"Found match via executable name: {exe_name} matches '{config_title or app_title}' ({match_type} match from {match_source})"
+                                        )
+                                        decky.logger.info(
+                                            f'Config file: {config_file}, key: {app_key}'
+                                        )
                                         return {
-                                            "status": "success",
-                                            "config_file": config_file,
-                                            "config_key": app_key
+                                            'status': 'success',
+                                            'config_file': config_file,
+                                            'config_key': app_key,
                                         }
                         except Exception as e:
-                            decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                            decky.logger.error(f'Error reading config file {config_file}: {e!s}')
 
             # Check install path as before
-            decky.logger.info("Trying to match using install path...")
-            games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+            decky.logger.info('Trying to match using install path...')
+            games_config_dir = os.path.expanduser(
+                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+            )
             for config_file in os.listdir(games_config_dir):
-                if not config_file.endswith(".json"):
+                if not config_file.endswith('.json'):
                     continue
 
                 config_file_path = os.path.join(games_config_dir, config_file)
@@ -1908,151 +2112,181 @@ class Plugin:
 
                         # Check all games in this config
                         for app_key, app_config in config_data.items():
-                            install_path = app_config.get("installPath", "")
+                            install_path = app_config.get('installPath', '')
                             if install_path:
                                 normalized_install_path = os.path.normpath(install_path)
                                 install_folder = os.path.basename(normalized_install_path).lower()
-                                install_folder_norm = install_folder.replace(" ", "").replace("-", "").replace("_", "")
+                                install_folder_norm = (
+                                    install_folder.replace(' ', '')
+                                    .replace('-', '')
+                                    .replace('_', '')
+                                )
 
                                 # Enhanced matching for install paths
-                                if (normalized_install_path == normalized_game_path or
-                                    install_folder == base_folder_name or
-                                    (normalized_game_name in install_folder_norm) or
-                                    (install_folder_norm in normalized_game_name) or
-                                    base_folder_name.startswith(install_folder_norm) or
-                                    install_folder_norm.startswith(base_folder_name)):
-
-                                    decky.logger.info(f"Found match via install path: {install_path}")
-                                    decky.logger.info(f"Config file: {config_file}, key: {app_key}")
+                                if (
+                                    normalized_install_path == normalized_game_path
+                                    or install_folder == base_folder_name
+                                    or (normalized_game_name in install_folder_norm)
+                                    or (install_folder_norm in normalized_game_name)
+                                    or base_folder_name.startswith(install_folder_norm)
+                                    or install_folder_norm.startswith(base_folder_name)
+                                ):
+                                    decky.logger.info(
+                                        f'Found match via install path: {install_path}'
+                                    )
+                                    decky.logger.info(f'Config file: {config_file}, key: {app_key}')
                                     return {
-                                        "status": "success",
-                                        "config_file": config_file,
-                                        "config_key": app_key
+                                        'status': 'success',
+                                        'config_file': config_file,
+                                        'config_key': app_key,
                                     }
                 except Exception as e:
-                    decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                    decky.logger.error(f'Error reading config file {config_file}: {e!s}')
 
             # NEW FALLBACK: Check store-specific installed.json files if all other methods fail
-            decky.logger.info("Trying to find game in store-specific installed.json files...")
+            decky.logger.info('Trying to find game in store-specific installed.json files...')
 
             # Define paths to different store installed.json files
             installed_json_paths = {
-                "epic": os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/legendaryConfig/legendary/installed.json"),
-                "gog": os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store/installed.json"),
-                "amazon": os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/nile_config/nile/installed.json")
+                'epic': os.path.expanduser(
+                    '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/legendaryConfig/legendary/installed.json'
+                ),
+                'gog': os.path.expanduser(
+                    '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store/installed.json'
+                ),
+                'amazon': os.path.expanduser(
+                    '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/nile_config/nile/installed.json'
+                ),
             }
 
             # Check each store's installed.json file
             for store, json_path in installed_json_paths.items():
                 if not os.path.exists(json_path):
-                    decky.logger.debug(f"{store.upper()} installed.json not found: {json_path}")
+                    decky.logger.debug(f'{store.upper()} installed.json not found: {json_path}')
                     continue
 
                 try:
                     with open(json_path, encoding='utf-8') as f:
                         installed_data = json.load(f)
 
-                    decky.logger.info(f"Checking {store.upper()} installed.json file")
+                    decky.logger.info(f'Checking {store.upper()} installed.json file')
 
                     # Handle Epic Games format (object with app IDs as keys)
-                    if store == "epic":
+                    if store == 'epic':
                         for app_id, game_info in installed_data.items():
-                            title = game_info.get("title", "").lower()
-                            title_norm = title.replace(" ", "").replace("-", "").replace("_", "")
-                            install_path = os.path.normpath(game_info.get("install_path", ""))
-                            executable = game_info.get("executable", "").lower()
-                            executable_name = os.path.splitext(executable)[0].lower() if executable else ""
+                            title = game_info.get('title', '').lower()
+                            title_norm = title.replace(' ', '').replace('-', '').replace('_', '')
+                            install_path = os.path.normpath(game_info.get('install_path', ''))
+                            executable = game_info.get('executable', '').lower()
+                            executable_name = (
+                                os.path.splitext(executable)[0].lower() if executable else ''
+                            )
 
                             # Comprehensive matching
-                            if (title.lower() == game_name.lower() or
-                                title_norm == normalized_game_name or
-                                normalized_game_name in title_norm or
-                                title_norm in normalized_game_name or
-                                install_path == normalized_game_path or
-                                os.path.basename(install_path).lower() == base_folder_name or
-                                (executable_name and (
-                                    executable_name == normalized_game_name or
-                                    normalized_game_name in executable_name or
-                                    executable_name in normalized_game_name
-                                ))):
-
-                                app_name = game_info.get("app_name", app_id)
+                            if (
+                                title.lower() == game_name.lower()
+                                or title_norm == normalized_game_name
+                                or normalized_game_name in title_norm
+                                or title_norm in normalized_game_name
+                                or install_path == normalized_game_path
+                                or os.path.basename(install_path).lower() == base_folder_name
+                                or (
+                                    executable_name
+                                    and (
+                                        executable_name == normalized_game_name
+                                        or normalized_game_name in executable_name
+                                        or executable_name in normalized_game_name
+                                    )
+                                )
+                            ):
+                                app_name = game_info.get('app_name', app_id)
                                 if app_name:
-                                    decky.logger.info(f"Found match in Epic installed.json: {app_name} for {title}")
+                                    decky.logger.info(
+                                        f'Found match in Epic installed.json: {app_name} for {title}'
+                                    )
 
                                     # Now search for this app_name in GamesConfig directory
                                     config_result = self._find_config_for_app_name(app_name)
-                                    if config_result["status"] == "success":
+                                    if config_result['status'] == 'success':
                                         return config_result
 
                     # Handle GOG format (installed array)
-                    elif store == "gog":
-                        installed_array = installed_data.get("installed", [])
+                    elif store == 'gog':
+                        installed_array = installed_data.get('installed', [])
                         for game_info in installed_array:
-                            install_path = os.path.normpath(game_info.get("install_path", ""))
-                            app_name = game_info.get("appName")
+                            install_path = os.path.normpath(game_info.get('install_path', ''))
+                            app_name = game_info.get('appName')
 
                             # Match based on install path
-                            if ((install_path == normalized_game_path or
-                                os.path.basename(install_path).lower() == base_folder_name) and
-                                app_name):
-                                    decky.logger.info(f"Found match in GOG installed.json: {app_name}")
+                            if (
+                                install_path == normalized_game_path
+                                or os.path.basename(install_path).lower() == base_folder_name
+                            ) and app_name:
+                                decky.logger.info(f'Found match in GOG installed.json: {app_name}')
+
+                                # Search for this app_name in config files
+                                config_result = self._find_config_for_app_name(app_name)
+                                if config_result['status'] == 'success':
+                                    return config_result
+
+                    # Handle Amazon format (likely similar to others)
+                    elif store == 'amazon':
+                        # Implementation would depend on exact structure
+                        # This is a placeholder assuming similar structure to other stores
+                        if isinstance(installed_data, dict) and 'installed' in installed_data:
+                            # Array format like GOG
+                            for game_info in installed_data.get('installed', []):
+                                app_name = game_info.get('appName') or game_info.get('app_name')
+                                install_path = os.path.normpath(game_info.get('install_path', ''))
+
+                                if (
+                                    install_path == normalized_game_path
+                                    or os.path.basename(install_path).lower() == base_folder_name
+                                ) and app_name:
+                                    decky.logger.info(
+                                        f'Found match in Amazon installed.json: {app_name}'
+                                    )
 
                                     # Search for this app_name in config files
                                     config_result = self._find_config_for_app_name(app_name)
-                                    if config_result["status"] == "success":
+                                    if config_result['status'] == 'success':
                                         return config_result
-
-                    # Handle Amazon format (likely similar to others)
-                    elif store == "amazon":
-                        # Implementation would depend on exact structure
-                        # This is a placeholder assuming similar structure to other stores
-                        if isinstance(installed_data, dict) and "installed" in installed_data:
-                            # Array format like GOG
-                            for game_info in installed_data.get("installed", []):
-                                app_name = game_info.get("appName") or game_info.get("app_name")
-                                install_path = os.path.normpath(game_info.get("install_path", ""))
-
-                                if ((install_path == normalized_game_path or
-                                    os.path.basename(install_path).lower() == base_folder_name) and
-                                    app_name):
-                                        decky.logger.info(f"Found match in Amazon installed.json: {app_name}")
-
-                                        # Search for this app_name in config files
-                                        config_result = self._find_config_for_app_name(app_name)
-                                        if config_result["status"] == "success":
-                                            return config_result
                         else:
                             # Object format like Epic
                             for _app_id, game_info in installed_data.items():
-                                app_name = game_info.get("appName") or game_info.get("app_name")
-                                install_path = os.path.normpath(game_info.get("install_path", ""))
+                                app_name = game_info.get('appName') or game_info.get('app_name')
+                                install_path = os.path.normpath(game_info.get('install_path', ''))
 
-                                if ((install_path == normalized_game_path or
-                                    os.path.basename(install_path).lower() == base_folder_name) and
-                                    app_name):
-                                        decky.logger.info(f"Found match in Amazon installed.json: {app_name}")
+                                if (
+                                    install_path == normalized_game_path
+                                    or os.path.basename(install_path).lower() == base_folder_name
+                                ) and app_name:
+                                    decky.logger.info(
+                                        f'Found match in Amazon installed.json: {app_name}'
+                                    )
 
-                                        # Search for this app_name in config files
-                                        config_result = self._find_config_for_app_name(app_name)
-                                        if config_result["status"] == "success":
-                                            return config_result
+                                    # Search for this app_name in config files
+                                    config_result = self._find_config_for_app_name(app_name)
+                                    if config_result['status'] == 'success':
+                                        return config_result
 
                 except Exception as e:
-                    decky.logger.error(f"Error reading {store} installed.json: {e!s}")
+                    decky.logger.error(f'Error reading {store} installed.json: {e!s}')
 
             # If we still couldn't find a match, look for appinfo.json
-            return {"status": "error", "message": f"Could not find config for game: {game_name}"}
+            return {'status': 'error', 'message': f'Could not find config for game: {game_name}'}
         except Exception as e:
-            decky.logger.error(f"Error finding Heroic game config: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error finding Heroic game config: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     def _find_config_for_app_name(self, app_name: str) -> dict:
         """Find config file containing the specified app_name as a key"""
-        games_config_dir = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig")
+        games_config_dir = os.path.expanduser(
+            '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig'
+        )
 
         for config_file in os.listdir(games_config_dir):
-            if not config_file.endswith(".json"):
+            if not config_file.endswith('.json'):
                 continue
 
             config_file_path = os.path.join(games_config_dir, config_file)
@@ -2061,35 +2295,46 @@ class Plugin:
                     config_data = json.load(f)
 
                     if app_name in config_data:
-                        decky.logger.info(f"Found config file for {app_name}: {config_file}")
+                        decky.logger.info(f'Found config file for {app_name}: {config_file}')
                         return {
-                            "status": "success",
-                            "config_file": config_file,
-                            "config_key": app_name
+                            'status': 'success',
+                            'config_file': config_file,
+                            'config_key': app_name,
                         }
             except Exception as e:
-                decky.logger.error(f"Error reading config file {config_file}: {e!s}")
+                decky.logger.error(f'Error reading config file {config_file}: {e!s}')
 
-        return {"status": "error", "message": f"No config file found for app name: {app_name}"}
+        return {'status': 'error', 'message': f'No config file found for app name: {app_name}'}
 
-    async def update_heroic_config(self, config_file: str, config_key: str, dll_override: str) -> dict:
+    async def update_heroic_config(
+        self, config_file: str, config_key: str, dll_override: str
+    ) -> dict:
         """Update Heroic game configuration with WINEDLLOVERRIDES for ReShade"""
         try:
-            config_path = os.path.expanduser("~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig/")
+            config_path = os.path.expanduser(
+                '~/.var/app/com.heroicgameslauncher.hgl/config/heroic/GamesConfig/'
+            )
             config_file_path = os.path.join(config_path, config_file)
 
             if not os.path.exists(config_file_path):
-                return {"status": "error", "message": f"Config file not found: {config_file}"}
+                return {'status': 'error', 'message': f'Config file not found: {config_file}'}
 
             # Read the config file
             with open(config_file_path, encoding='utf-8') as f:
                 config_data = json.load(f)
 
             if config_key not in config_data:
-                return {"status": "error", "message": f"Game config key '{config_key}' not found in config file"}
+                return {
+                    'status': 'error',
+                    'message': f"Game config key '{config_key}' not found in config file",
+                }
 
             # Check if environmentOptions exists (note: it's "environmentOptions" in newer versions, not "enviromentOptions")
-            env_key = "environmentOptions" if "environmentOptions" in config_data[config_key] else "enviromentOptions"
+            env_key = (
+                'environmentOptions'
+                if 'environmentOptions' in config_data[config_key]
+                else 'enviromentOptions'
+            )
 
             if env_key not in config_data[config_key]:
                 config_data[config_key][env_key] = []
@@ -2097,62 +2342,75 @@ class Plugin:
             # Handle WINEDLLOVERRIDES
             # Remove any existing WINEDLLOVERRIDES
             config_data[config_key][env_key] = [
-                env for env in config_data[config_key][env_key]
-                if env.get("key") != "WINEDLLOVERRIDES"
+                env
+                for env in config_data[config_key][env_key]
+                if env.get('key') != 'WINEDLLOVERRIDES'
             ]
 
             # Add new WINEDLLOVERRIDES if not removing
-            if dll_override != "remove":
-                config_data[config_key][env_key].append({
-                    "key": "WINEDLLOVERRIDES",
-                    "value": f"d3dcompiler_47=n;{dll_override}=n,b"
-                })
+            if dll_override != 'remove':
+                config_data[config_key][env_key].append(
+                    {'key': 'WINEDLLOVERRIDES', 'value': f'd3dcompiler_47=n;{dll_override}=n,b'}
+                )
 
             # Write back the updated config
             with open(config_file_path, 'w', encoding='utf-8') as f:
                 json.dump(config_data, f, indent=2)
 
-            return {"status": "success", "output": f"Updated Heroic config with {dll_override} override."}
+            return {
+                'status': 'success',
+                'output': f'Updated Heroic config with {dll_override} override.',
+            }
         except Exception as e:
-            decky.logger.error(f"Error updating Heroic config: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error updating Heroic config: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
-    async def install_reshade_for_heroic_game(self, game_path: str, dll_override: str = "d3d9", selected_executable_path: str = "") -> dict:
+    async def install_reshade_for_heroic_game(
+        self, game_path: str, dll_override: str = 'd3d9', selected_executable_path: str = ''
+    ) -> dict:
         """Install ReShade for a Heroic game by copying files instead of symlinks and properly configuring ReShade.ini"""
         try:
-            decky.logger.info(f"Installing ReShade for Heroic game at: {game_path}")
+            decky.logger.info(f'Installing ReShade for Heroic game at: {game_path}')
 
             # Verify ReShade is installed
-            marker_file = Path(self.main_path) / ".installed"
-            addon_marker = Path(self.main_path) / ".installed_addon"
+            marker_file = Path(self.main_path) / '.installed'
+            addon_marker = Path(self.main_path) / '.installed_addon'
             if not marker_file.exists() and not addon_marker.exists():
-                return {"status": "error", "message": "ReShade is not installed. Please install ReShade first."}
+                return {
+                    'status': 'error',
+                    'message': 'ReShade is not installed. Please install ReShade first.',
+                }
 
             # Verify game path exists
             if not os.path.exists(game_path):
-                return {"status": "error", "message": f"Game path not found: {game_path}"}
+                return {'status': 'error', 'message': f'Game path not found: {game_path}'}
 
             # Determine the target directory for ReShade installation
             if selected_executable_path and os.path.exists(selected_executable_path):
                 # Use the directory of the selected executable
                 exe_dir = os.path.dirname(selected_executable_path)
-                decky.logger.info(f"Using user-selected executable directory: {exe_dir}")
+                decky.logger.info(f'Using user-selected executable directory: {exe_dir}')
             else:
                 # Find the actual executable directory using smart detection
                 exe_dir = self._find_heroic_game_executable_directory(game_path)
                 if not exe_dir:
-                    decky.logger.warning(f"Could not find executable directory, using provided path: {game_path}")
+                    decky.logger.warning(
+                        f'Could not find executable directory, using provided path: {game_path}'
+                    )
                     exe_dir = game_path
                 else:
-                    decky.logger.info(f"Found executable directory: {exe_dir}")
+                    decky.logger.info(f'Found executable directory: {exe_dir}')
 
             # Find architecture by checking for .exe files
-            arch = "64"  # Default to 64-bit
+            arch = '64'  # Default to 64-bit
 
             for file in os.listdir(exe_dir):
-                if file.lower().endswith(".exe"):
+                if file.lower().endswith('.exe'):
                     # Skip known utility executables
-                    if any(skip in file.lower() for skip in ["unins", "launcher", "crash", "setup", "config", "redist"]):
+                    if any(
+                        skip in file.lower()
+                        for skip in ['unins', 'launcher', 'crash', 'setup', 'config', 'redist']
+                    ):
                         continue
 
                     exe_path = os.path.join(exe_dir, file)
@@ -2160,36 +2418,36 @@ class Plugin:
                         # Check if 32-bit or 64-bit using the 'file' command
                         # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
                         clean_env = os.environ.copy()
-                        clean_env["LD_LIBRARY_PATH"] = ""
+                        clean_env['LD_LIBRARY_PATH'] = ''
 
                         process = subprocess.run(
-                            ["file", exe_path],
-                            capture_output=True,
-                            text=True,
-                            env=clean_env
+                            ['file', exe_path], capture_output=True, text=True, env=clean_env
                         )
 
-                        if "PE32 executable" in process.stdout and "PE32+" not in process.stdout:
-                            arch = "32"
-                            decky.logger.info(f"Found 32-bit executable: {exe_path}")
+                        if 'PE32 executable' in process.stdout and 'PE32+' not in process.stdout:
+                            arch = '32'
+                            decky.logger.info(f'Found 32-bit executable: {exe_path}')
                             break
-                        elif "PE32+ executable" in process.stdout or "x86-64" in process.stdout:
-                            decky.logger.info(f"Found 64-bit executable: {exe_path}")
+                        elif 'PE32+ executable' in process.stdout or 'x86-64' in process.stdout:
+                            decky.logger.info(f'Found 64-bit executable: {exe_path}')
                     except Exception as e:
-                        decky.logger.error(f"Error checking EXE architecture: {e!s}")
+                        decky.logger.error(f'Error checking EXE architecture: {e!s}')
 
-            decky.logger.info(f"Using architecture: {arch}-bit")
+            decky.logger.info(f'Using architecture: {arch}-bit')
 
             # Source paths for DLLs
-            reshade_dll_src = os.path.join(self.main_path, "reshade/latest", f"ReShade{arch}.dll")
-            d3dcompiler_src = os.path.join(self.main_path, "reshade", f"d3dcompiler_47.dll.{arch}")
+            reshade_dll_src = os.path.join(self.main_path, 'reshade/latest', f'ReShade{arch}.dll')
+            d3dcompiler_src = os.path.join(self.main_path, 'reshade', f'd3dcompiler_47.dll.{arch}')
 
             if not os.path.exists(reshade_dll_src) or not os.path.exists(d3dcompiler_src):
-                return {"status": "error", "message": "ReShade DLL files not found. Please reinstall ReShade."}
+                return {
+                    'status': 'error',
+                    'message': 'ReShade DLL files not found. Please reinstall ReShade.',
+                }
 
             # Destination paths
-            reshade_dll_dst = os.path.join(exe_dir, f"{dll_override}.dll")
-            d3dcompiler_dst = os.path.join(exe_dir, "d3dcompiler_47.dll")
+            reshade_dll_dst = os.path.join(exe_dir, f'{dll_override}.dll')
+            d3dcompiler_dst = os.path.join(exe_dir, 'd3dcompiler_47.dll')
 
             # Copy files instead of creating symlinks
             shutil.copy2(reshade_dll_src, reshade_dll_dst)
@@ -2200,8 +2458,8 @@ class Plugin:
             os.chmod(d3dcompiler_dst, 0o666)
 
             # Copy shader directory if exists
-            if os.path.exists(os.path.join(self.main_path, "ReShade_shaders")):
-                shaders_dst = os.path.join(exe_dir, "ReShade_shaders")
+            if os.path.exists(os.path.join(self.main_path, 'ReShade_shaders')):
+                shaders_dst = os.path.join(exe_dir, 'ReShade_shaders')
                 # Check if it already exists
                 if os.path.exists(shaders_dst):
                     # Remove old link/directory
@@ -2210,11 +2468,11 @@ class Plugin:
                     else:
                         shutil.rmtree(shaders_dst)
                 # Create the directory and copy files
-                shutil.copytree(os.path.join(self.main_path, "ReShade_shaders"), shaders_dst)
+                shutil.copytree(os.path.join(self.main_path, 'ReShade_shaders'), shaders_dst)
 
             # Fix ReShade.ini to use local paths instead of system paths
-            reshade_ini_src = os.path.join(self.main_path, "ReShade.ini")
-            reshade_ini_dst = os.path.join(exe_dir, "ReShade.ini")
+            reshade_ini_src = os.path.join(self.main_path, 'ReShade.ini')
+            reshade_ini_dst = os.path.join(exe_dir, 'ReShade.ini')
 
             if os.path.exists(reshade_ini_src):
                 # Read the original file
@@ -2226,18 +2484,37 @@ class Plugin:
 
                 # First, detect if we're using merged shaders
                 merged_path = False
-                if "ReShade_shaders\\Merged\\Shaders" in ini_content or "ReShade_shaders/Merged/Shaders" in ini_content:
+                if (
+                    'ReShade_shaders\\Merged\\Shaders' in ini_content
+                    or 'ReShade_shaders/Merged/Shaders' in ini_content
+                ):
                     merged_path = True
 
                 # Replace system paths with relative game paths (convert to Windows format for Wine)
                 if merged_path:
                     # For merged shader setup
-                    ini_content = re.sub(r'EffectSearchPaths=.*', r'EffectSearchPaths=.\\ReShade_shaders\\Merged\\Shaders', ini_content)
-                    ini_content = re.sub(r'TextureSearchPaths=.*', r'TextureSearchPaths=.\\ReShade_shaders\\Merged\\Textures', ini_content)
+                    ini_content = re.sub(
+                        r'EffectSearchPaths=.*',
+                        r'EffectSearchPaths=.\\ReShade_shaders\\Merged\\Shaders',
+                        ini_content,
+                    )
+                    ini_content = re.sub(
+                        r'TextureSearchPaths=.*',
+                        r'TextureSearchPaths=.\\ReShade_shaders\\Merged\\Textures',
+                        ini_content,
+                    )
                 else:
                     # For individual shader repositories
-                    ini_content = re.sub(r'EffectSearchPaths=.*', r'EffectSearchPaths=.\\ReShade_shaders', ini_content)
-                    ini_content = re.sub(r'TextureSearchPaths=.*', r'TextureSearchPaths=.\\ReShade_shaders', ini_content)
+                    ini_content = re.sub(
+                        r'EffectSearchPaths=.*',
+                        r'EffectSearchPaths=.\\ReShade_shaders',
+                        ini_content,
+                    )
+                    ini_content = re.sub(
+                        r'TextureSearchPaths=.*',
+                        r'TextureSearchPaths=.\\ReShade_shaders',
+                        ini_content,
+                    )
 
                 # Update the PresetPath to use the local directory
                 ini_content = re.sub(r'PresetPath=.*', r'PresetPath=.', ini_content)
@@ -2270,7 +2547,7 @@ KeyPreviousPreset=0
                 os.chmod(reshade_ini_dst, 0o666)
 
             # Handle ReShadePreset.ini - preserve existing user settings
-            reshade_preset_dst = os.path.join(exe_dir, "ReShadePreset.ini")
+            reshade_preset_dst = os.path.join(exe_dir, 'ReShadePreset.ini')
 
             # Only create the file if it doesn't already exist (preserve existing user settings)
             if not os.path.exists(reshade_preset_dst):
@@ -2294,25 +2571,29 @@ KeyPreviousPreset=0
 
                 # Set proper permissions for ReShadePreset.ini (read/write for all)
                 os.chmod(reshade_preset_dst, 0o666)
-                decky.logger.info("Created new ReShadePreset.ini with proper permissions")
+                decky.logger.info('Created new ReShadePreset.ini with proper permissions')
             else:
                 # File exists, just ensure it has proper permissions
                 os.chmod(reshade_preset_dst, 0o666)
-                decky.logger.info("ReShadePreset.ini already exists, updated permissions only")
+                decky.logger.info('ReShadePreset.ini already exists, updated permissions only')
 
             # Create a README file to help users with the configuration
-            readme_path = os.path.join(exe_dir, "ReShade_README.txt")
+            readme_path = os.path.join(exe_dir, 'ReShade_README.txt')
 
             # Check if AutoHDR was actually installed
-            autohdr_installed = os.path.exists(os.path.join(exe_dir, f"AutoHDR.addon{arch}"))
+            autohdr_installed = os.path.exists(os.path.join(exe_dir, f'AutoHDR.addon{arch}'))
             autohdr_compatible = dll_override.lower() in ['dxgi', 'd3d11', 'd3d12']
 
             if autohdr_installed:
-                autohdr_status = f"- AutoHDR.addon{arch}: AutoHDR addon (DirectX 10/11/12 compatible)"
+                autohdr_status = (
+                    f'- AutoHDR.addon{arch}: AutoHDR addon (DirectX 10/11/12 compatible)'
+                )
             elif autohdr_compatible:
-                autohdr_status = f"- AutoHDR.addon{arch}: Not installed (AutoHDR addon file missing)"
+                autohdr_status = (
+                    f'- AutoHDR.addon{arch}: Not installed (AutoHDR addon file missing)'
+                )
             else:
-                autohdr_status = f"- AutoHDR.addon{arch}: Not compatible with {dll_override} (requires DirectX 10/11/12)"
+                autohdr_status = f'- AutoHDR.addon{arch}: Not compatible with {dll_override} (requires DirectX 10/11/12)'
 
             with open(readme_path, 'w', encoding='utf-8') as f:
                 f.write(f"""ReShade for {os.path.basename(game_path)}
@@ -2358,30 +2639,41 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
             autohdr_compatible = dll_override.lower() in ['dxgi', 'd3d11', 'd3d12']
 
             if autohdr_compatible:
-                autohdr_addon_path = os.path.join(self.main_path, "AutoHDR_addons", f"AutoHDR.addon{arch}")
+                autohdr_addon_path = os.path.join(
+                    self.main_path, 'AutoHDR_addons', f'AutoHDR.addon{arch}'
+                )
                 if os.path.exists(autohdr_addon_path):
-                    autohdr_dst = os.path.join(exe_dir, f"AutoHDR.addon{arch}")
+                    autohdr_dst = os.path.join(exe_dir, f'AutoHDR.addon{arch}')
                     try:
                         shutil.copy2(autohdr_addon_path, autohdr_dst)
                         os.chmod(autohdr_dst, 0o666)
-                        decky.logger.info(f"AutoHDR addon copied successfully for {arch}-bit architecture (API: {dll_override})")
+                        decky.logger.info(
+                            f'AutoHDR addon copied successfully for {arch}-bit architecture (API: {dll_override})'
+                        )
                     except Exception as e:
-                        decky.logger.warning(f"Failed to copy AutoHDR addon: {e!s}")
+                        decky.logger.warning(f'Failed to copy AutoHDR addon: {e!s}')
                 else:
-                    decky.logger.info(f"AutoHDR addon file not found: {autohdr_addon_path}")
+                    decky.logger.info(f'AutoHDR addon file not found: {autohdr_addon_path}')
             else:
-                decky.logger.info(f"Skipping AutoHDR addon installation for API: {dll_override} (requires DirectX 10/11/12)")
+                decky.logger.info(
+                    f'Skipping AutoHDR addon installation for API: {dll_override} (requires DirectX 10/11/12)'
+                )
                 # Remove any existing AutoHDR addon files if they exist from previous installations
                 for addon_arch in ['32', '64']:
-                    existing_addon = os.path.join(exe_dir, f"AutoHDR.addon{addon_arch}")
+                    existing_addon = os.path.join(exe_dir, f'AutoHDR.addon{addon_arch}')
                     if os.path.exists(existing_addon):
-                        decky.logger.info(f"Removing existing AutoHDR addon (incompatible with {dll_override})")
+                        decky.logger.info(
+                            f'Removing existing AutoHDR addon (incompatible with {dll_override})'
+                        )
                         os.remove(existing_addon)
 
-            return {"status": "success", "output": f"ReShade installed successfully for Heroic game using {dll_override} override."}
+            return {
+                'status': 'success',
+                'output': f'ReShade installed successfully for Heroic game using {dll_override} override.',
+            }
         except Exception as e:
-            decky.logger.error(f"Error installing ReShade for Heroic game: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error installing ReShade for Heroic game: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     def _find_game_executable_directory(self, path: Path, game_name: str) -> tuple[Path, float]:
         """
@@ -2403,8 +2695,8 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
             # Clean game name (remove spaces, special chars)
             clean_game_name = re.sub(r'[^a-z0-9]', '', game_name.lower())
 
-            decky.logger.info(f"Looking for executables for game: {game_name}")
-            decky.logger.info(f"Game words for matching: {game_words}")
+            decky.logger.info(f'Looking for executables for game: {game_name}')
+            decky.logger.info(f'Game words for matching: {game_words}')
 
             def analyze_directory_content(dir_path: Path) -> float:
                 """Score a directory based on its content"""
@@ -2431,7 +2723,16 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                                 file_types['config'] += 1
 
                             # Game asset files
-                            elif ext in ['.pak', '.dat', '.bsa', '.ba2', '.dds', '.tga', '.png', '.jpg']:
+                            elif ext in [
+                                '.pak',
+                                '.dat',
+                                '.bsa',
+                                '.ba2',
+                                '.dds',
+                                '.tga',
+                                '.png',
+                                '.jpg',
+                            ]:
                                 file_types['asset'] += 1
 
                             # Setup and redistributable files (negative indicators)
@@ -2440,7 +2741,10 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
 
                             # Check file names for redistributable indicators
                             file_name = file.name.lower()
-                            if any(term in file_name for term in ['redist', 'vcredist', 'directx', 'setup', 'install']):
+                            if any(
+                                term in file_name
+                                for term in ['redist', 'vcredist', 'directx', 'setup', 'install']
+                            ):
                                 file_types['redist'] += 1
 
                     # Score based on file types
@@ -2468,7 +2772,9 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                         score += 2  # Partial match
                     elif dir_name in ['bin', 'bin64', 'bin32', 'binaries', 'game', 'main']:
                         score += 2  # Common game directories
-                    elif any(term in dir_name for term in ['redist', 'setup', 'support', 'tools', 'eadm']):
+                    elif any(
+                        term in dir_name for term in ['redist', 'setup', 'support', 'tools', 'eadm']
+                    ):
                         score -= 2  # Negative indicators
 
                     # Analyze subdirectory names
@@ -2476,18 +2782,25 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                     subdir_names = [d.name.lower() for d in subdirs]
 
                     # Game directories often have these subdirectories
-                    game_subdir_indicators = ['data', 'config', 'save', 'content', 'assets', 'levels']
+                    game_subdir_indicators = [
+                        'data',
+                        'config',
+                        'save',
+                        'content',
+                        'assets',
+                        'levels',
+                    ]
                     for indicator in game_subdir_indicators:
                         if any(indicator in name for name in subdir_names):
                             score += 0.5
 
                     # Round to 1 decimal place
                     score = round(score, 1)
-                    decky.logger.debug(f"Directory content score for {dir_path}: {score}")
+                    decky.logger.debug(f'Directory content score for {dir_path}: {score}')
                     return score
 
                 except (PermissionError, OSError) as e:
-                    decky.logger.debug(f"Error analyzing directory {dir_path}: {e}")
+                    decky.logger.debug(f'Error analyzing directory {dir_path}: {e}')
                     return 0
 
             def score_executable(exe_path: Path) -> float:
@@ -2499,10 +2812,21 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                 score = 0
 
                 # Skip utility executables
-                if any(skip in name for skip in ["unins", "launcher", "crash", "setup", "config", "redist", "install"]):
+                if any(
+                    skip in name
+                    for skip in [
+                        'unins',
+                        'launcher',
+                        'crash',
+                        'setup',
+                        'config',
+                        'redist',
+                        'install',
+                    ]
+                ):
                     return 0
 
-                decky.logger.debug(f"Scoring executable: {name}")
+                decky.logger.debug(f'Scoring executable: {name}')
 
                 # Enhanced name matching for specific cases
                 clean_exe_name = re.sub(r'[^a-z0-9]', '', name)
@@ -2510,26 +2834,35 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                 # Check exact match (normalized)
                 if clean_exe_name == clean_game_name:
                     exact_match_score = 30
-                    decky.logger.debug(f"  Exact normalized match: +{exact_match_score}")
+                    decky.logger.debug(f'  Exact normalized match: +{exact_match_score}')
                     score += exact_match_score
 
                 # Handle special cases like "among us.exe" vs "amongus"
-                elif name.replace(" ", "") == game_name.lower() or game_name.lower().replace(" ", "") == name:
+                elif (
+                    name.replace(' ', '') == game_name.lower()
+                    or game_name.lower().replace(' ', '') == name
+                ):
                     special_match_score = 25
-                    decky.logger.debug(f"  Special space-normalized match: +{special_match_score}")
+                    decky.logger.debug(f'  Special space-normalized match: +{special_match_score}')
                     score += special_match_score
 
                 # Check partial matches
                 elif clean_game_name in clean_exe_name or clean_exe_name in clean_game_name:
                     # Calculate how much of the string matches
                     match_ratio = max(
-                        len(clean_game_name) / len(clean_exe_name) if len(clean_exe_name) > 0 else 0,
-                        len(clean_exe_name) / len(clean_game_name) if len(clean_game_name) > 0 else 0
+                        len(clean_game_name) / len(clean_exe_name)
+                        if len(clean_exe_name) > 0
+                        else 0,
+                        len(clean_exe_name) / len(clean_game_name)
+                        if len(clean_game_name) > 0
+                        else 0,
                     )
                     # Scale the score (max 20 points)
                     partial_score = min(20, int(match_ratio * 20))
                     score += partial_score
-                    decky.logger.debug(f"  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})")
+                    decky.logger.debug(
+                        f'  Partial name match: +{partial_score} (ratio: {match_ratio:.2f})'
+                    )
 
                 # Word-based matching
                 else:
@@ -2541,16 +2874,22 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
 
                     # If there are matching words, they're worth MUCH more if they're a larger percentage of the game name
                     if matching_words:
-                        match_percentage = len(matching_words) / len(game_words) if game_words else 0
-                        word_score = len(matching_words) * 5.0 * (1 + match_percentage)  # Increased from 1.5 to 5.0
+                        match_percentage = (
+                            len(matching_words) / len(game_words) if game_words else 0
+                        )
+                        word_score = (
+                            len(matching_words) * 5.0 * (1 + match_percentage)
+                        )  # Increased from 1.5 to 5.0
                         word_score = min(15, round(word_score, 1))  # Cap at 15 and round
-                        decky.logger.debug(f"  Name match score: +{word_score} (words: {matching_words})")
+                        decky.logger.debug(
+                            f'  Name match score: +{word_score} (words: {matching_words})'
+                        )
                         score += word_score
 
                 # Bonus for common game executable names (increased)
-                if name.lower() in ["game", "start", "play", "client", "app"]:
+                if name.lower() in ['game', 'start', 'play', 'client', 'app']:
                     common_name_score = 5.0  # Increased from 0.5 to 5.0
-                    decky.logger.debug(f"  Common name bonus: +{common_name_score} ({name})")
+                    decky.logger.debug(f'  Common name bonus: +{common_name_score} ({name})')
                     score += common_name_score
 
                 try:
@@ -2561,29 +2900,32 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                     # Reduced logarithmic scoring for size - much lower weight
                     if size_mb > 0:
                         import math
-                        size_score = min(0.5, math.log10(size_mb) / 6)  # Significantly reduced weight for size
+
+                        size_score = min(
+                            0.5, math.log10(size_mb) / 6
+                        )  # Significantly reduced weight for size
                         size_score = round(size_score, 1)  # Round to 1 decimal
-                        decky.logger.debug(f"  Size score: +{size_score} ({size_mb:.2f} MB)")
+                        decky.logger.debug(f'  Size score: +{size_score} ({size_mb:.2f} MB)')
                         score += size_score
 
                     # Smaller penalty for extremely small executables
                     if size_mb < 0.5:  # Less than 500KB
                         size_penalty = 0.5  # Reduced from 1
-                        decky.logger.debug(f"  Small size penalty: -{size_penalty}")
+                        decky.logger.debug(f'  Small size penalty: -{size_penalty}')
                         score -= size_penalty
                 except Exception as e:
-                    decky.logger.debug(f"  Error checking file size: {e}")
+                    decky.logger.debug(f'  Error checking file size: {e}')
 
                 # If the name contains "launcher" or "setup", reduce score significantly
-                if "launcher" in name.lower() or "setup" in name.lower():
+                if 'launcher' in name.lower() or 'setup' in name.lower():
                     launcher_penalty = 10  # Increased from 3 to 10
-                    decky.logger.debug(f"  Launcher/setup penalty: -{launcher_penalty}")
+                    decky.logger.debug(f'  Launcher/setup penalty: -{launcher_penalty}')
                     score -= launcher_penalty
 
                 # Round score to 1 decimal place
                 score = round(score, 1)
 
-                decky.logger.debug(f"  Final executable score: {score}")
+                decky.logger.debug(f'  Final executable score: {score}')
                 return score
 
             def find_best_exe_dir(path: Path, max_depth=3, current_depth=0) -> tuple[Path, float]:
@@ -2597,7 +2939,7 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                 try:
                     # First check for executables in this directory
                     exes_in_dir = []
-                    for exe in path.glob("*.exe"):
+                    for exe in path.glob('*.exe'):
                         exe_score = score_executable(exe)
                         if exe_score > 0:
                             exes_in_dir.append((exe, exe_score))
@@ -2612,7 +2954,9 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                     if exes_in_dir:
                         best_exe_score = exes_in_dir[0][1]
                         combined_score = best_exe_score + dir_content_score
-                        decky.logger.debug(f"Directory {path} - Best exe: {exes_in_dir[0][0].name} (score: {best_exe_score:.1f}), Dir content: {dir_content_score:.1f}, Combined: {combined_score:.1f}")
+                        decky.logger.debug(
+                            f'Directory {path} - Best exe: {exes_in_dir[0][0].name} (score: {best_exe_score:.1f}), Dir content: {dir_content_score:.1f}, Combined: {combined_score:.1f}'
+                        )
 
                         if combined_score > best_score:
                             best_score = combined_score
@@ -2627,13 +2971,15 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                     if (best_score < 4 or current_depth == 0) and current_depth < max_depth:
                         for subdir in path.iterdir():
                             if subdir.is_dir():
-                                sub_exe_dir, sub_score = find_best_exe_dir(subdir, max_depth, current_depth + 1)
+                                sub_exe_dir, sub_score = find_best_exe_dir(
+                                    subdir, max_depth, current_depth + 1
+                                )
                                 if sub_score > best_score:
                                     best_score = sub_score
                                     best_exe_dir = sub_exe_dir
 
                 except (PermissionError, OSError) as e:
-                    decky.logger.debug(f"Error accessing directory {path}: {e}")
+                    decky.logger.debug(f'Error accessing directory {path}: {e}')
 
                 # Round final score to 1 decimal
                 best_score = round(best_score, 1)
@@ -2646,7 +2992,7 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
             return best_dir, score
 
         except Exception as e:
-            decky.logger.error(f"Error in _find_game_executable_directory: {e!s}")
+            decky.logger.error(f'Error in _find_game_executable_directory: {e!s}')
             return path, 0
 
     def _find_heroic_game_executable_directory(self, game_path: str) -> str:
@@ -2657,103 +3003,149 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                 return None
 
             # Get name of the game directory for smarter exe matching
-            game_name = game_path.name.lower().replace("_", " ").replace("-", " ")
+            game_name = game_path.name.lower().replace('_', ' ').replace('-', ' ')
 
-            decky.logger.info(f"Finding executable directory for Heroic game: {game_name}")
+            decky.logger.info(f'Finding executable directory for Heroic game: {game_name}')
 
             # Use the unified game executable detection function
             best_dir, score = self._find_game_executable_directory(game_path, game_name)
 
             if best_dir and score > 0:
-                decky.logger.info(f"Found game executable directory: {best_dir} (score: {score:.2f})")
+                decky.logger.info(
+                    f'Found game executable directory: {best_dir} (score: {score:.2f})'
+                )
                 return str(best_dir)
 
             # If we couldn't find anything, check some common subdirectories
-            common_dirs = ["bin", "bin32", "bin64", "binaries", "game", "win64", "win32", "x64", "x86"]
+            common_dirs = [
+                'bin',
+                'bin32',
+                'bin64',
+                'binaries',
+                'game',
+                'win64',
+                'win32',
+                'x64',
+                'x86',
+            ]
             for common in common_dirs:
                 test_path = game_path / common
                 if test_path.exists() and test_path.is_dir():
-                    exes = list(test_path.glob("*.exe"))
+                    exes = list(test_path.glob('*.exe'))
                     if exes:
-                        decky.logger.info(f"Using common executable directory: {test_path}")
+                        decky.logger.info(f'Using common executable directory: {test_path}')
                         return str(test_path)
 
             # If we still didn't find anything, just use the original path
-            decky.logger.info(f"No suitable executable directory found, using original path: {game_path}")
+            decky.logger.info(
+                f'No suitable executable directory found, using original path: {game_path}'
+            )
             return str(game_path)
 
         except Exception as e:
-            decky.logger.error(f"Error finding game executable directory: {e!s}")
+            decky.logger.error(f'Error finding game executable directory: {e!s}')
             return None
 
     def _find_game_path(self, appid: str) -> str:
-        steam_root = Path(decky.HOME) / ".steam" / "steam"
-        library_file = steam_root / "steamapps" / "libraryfolders.vdf"
+        steam_root = Path(decky.HOME) / '.steam' / 'steam'
+        library_file = steam_root / 'steamapps' / 'libraryfolders.vdf'
 
         if not library_file.exists():
-            raise ValueError(f"Steam library file not found: {library_file}")
+            raise ValueError(f'Steam library file not found: {library_file}')
 
         library_paths = []
-        with open(library_file, encoding="utf-8") as file:
+        with open(library_file, encoding='utf-8') as file:
             for line in file:
                 if '"path"' in line:
-                    path = line.split('"path"')[1].strip().strip('"').replace("\\\\", "/")
+                    path = line.split('"path"')[1].strip().strip('"').replace('\\\\', '/')
                     library_paths.append(path)
 
         for library_path in library_paths:
-            manifest_path = Path(library_path) / "steamapps" / f"appmanifest_{appid}.acf"
+            manifest_path = Path(library_path) / 'steamapps' / f'appmanifest_{appid}.acf'
             if manifest_path.exists():
-                with open(manifest_path, encoding="utf-8") as manifest:
+                with open(manifest_path, encoding='utf-8') as manifest:
                     for line in manifest:
                         if '"installdir"' in line:
                             install_dir = line.split('"installdir"')[1].strip().strip('"')
-                            base_path = Path(library_path) / "steamapps" / "common" / install_dir
+                            base_path = Path(library_path) / 'steamapps' / 'common' / install_dir
 
                             # Get name of the game directory for smarter exe matching
-                            game_name = install_dir.lower().replace("_", " ").replace("-", " ")
+                            game_name = install_dir.lower().replace('_', ' ').replace('-', ' ')
 
-                            decky.logger.info(f"Finding executable directory for Steam game: {game_name}")
+                            decky.logger.info(
+                                f'Finding executable directory for Steam game: {game_name}'
+                            )
 
                             # Use the unified game executable detection function
-                            best_dir, score = self._find_game_executable_directory(base_path, game_name)
+                            best_dir, score = self._find_game_executable_directory(
+                                base_path, game_name
+                            )
 
                             if best_dir and score > 0:
-                                decky.logger.info(f"Found game executable directory: {best_dir} (score: {score:.2f})")
+                                decky.logger.info(
+                                    f'Found game executable directory: {best_dir} (score: {score:.2f})'
+                                )
                                 return str(best_dir)
 
                             # If we couldn't find anything, check some common subdirectories
-                            common_dirs = ["bin", "bin32", "bin64", "binaries", "game", "win64", "win32", "x64", "x86"]
+                            common_dirs = [
+                                'bin',
+                                'bin32',
+                                'bin64',
+                                'binaries',
+                                'game',
+                                'win64',
+                                'win32',
+                                'x64',
+                                'x86',
+                            ]
                             for common in common_dirs:
                                 test_path = base_path / common
                                 if test_path.exists() and test_path.is_dir():
-                                    exes = list(test_path.glob("*.exe"))
+                                    exes = list(test_path.glob('*.exe'))
                                     if exes:
-                                        decky.logger.info(f"Using common executable directory: {test_path}")
+                                        decky.logger.info(
+                                            f'Using common executable directory: {test_path}'
+                                        )
                                         return str(test_path)
 
                             # If we still didn't find anything, just use the original path
-                            decky.logger.info(f"No suitable executable directory found, using base path: {base_path}")
+                            decky.logger.info(
+                                f'No suitable executable directory found, using base path: {base_path}'
+                            )
                             return str(base_path)
 
-        raise ValueError(f"Could not find installation directory for AppID: {appid}")
+        raise ValueError(f'Could not find installation directory for AppID: {appid}')
 
     async def uninstall_reshade_for_heroic_game(self, game_path: str) -> dict:
         """Uninstall ReShade from a Heroic game while preserving user presets"""
         try:
-            decky.logger.info(f"Uninstalling ReShade from Heroic game at: {game_path}")
+            decky.logger.info(f'Uninstalling ReShade from Heroic game at: {game_path}')
 
             # Find the executable directory
             exe_dir = self._find_heroic_game_executable_directory(game_path)
             if not exe_dir:
-                decky.logger.warning(f"Could not find executable directory, using provided path: {game_path}")
+                decky.logger.warning(
+                    f'Could not find executable directory, using provided path: {game_path}'
+                )
                 exe_dir = game_path
 
             # Remove ReShade files (excluding ReShadePreset.ini to preserve user settings)
             reshade_files = [
-                "d3d8.dll", "d3d9.dll", "d3d10.dll", "d3d11.dll", "d3d12.dll",
-                "dxgi.dll", "opengl32.dll", "dinput8.dll", "ddraw.dll",
-                "d3dcompiler_47.dll", "ReShade.ini", "ReShade_README.txt",
-                "AutoHDR.addon32", "AutoHDR.addon64"
+                'd3d8.dll',
+                'd3d9.dll',
+                'd3d10.dll',
+                'd3d11.dll',
+                'd3d12.dll',
+                'dxgi.dll',
+                'opengl32.dll',
+                'dinput8.dll',
+                'ddraw.dll',
+                'd3dcompiler_47.dll',
+                'ReShade.ini',
+                'ReShade_README.txt',
+                'AutoHDR.addon32',
+                'AutoHDR.addon64',
                 # Note: ReShadePreset.ini is intentionally excluded to preserve user settings
             ]
 
@@ -2761,49 +3153,55 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                 file_path = os.path.join(exe_dir, file)
                 if os.path.exists(file_path):
                     os.remove(file_path)
-                    decky.logger.info(f"Removed {file_path}")
+                    decky.logger.info(f'Removed {file_path}')
 
             # Remove ReShade_shaders directory if it exists
-            shaders_path = os.path.join(exe_dir, "ReShade_shaders")
+            shaders_path = os.path.join(exe_dir, 'ReShade_shaders')
             if os.path.exists(shaders_path):
                 if os.path.islink(shaders_path):
                     os.unlink(shaders_path)
                 else:
                     shutil.rmtree(shaders_path)
-                decky.logger.info(f"Removed {shaders_path}")
+                decky.logger.info(f'Removed {shaders_path}')
 
             # Check if ReShadePreset.ini exists and inform user it's preserved
-            preset_path = os.path.join(exe_dir, "ReShadePreset.ini")
+            preset_path = os.path.join(exe_dir, 'ReShadePreset.ini')
             if os.path.exists(preset_path):
-                decky.logger.info(f"ReShadePreset.ini preserved at {preset_path}")
-                return {"status": "success", "output": "ReShade uninstalled successfully.\nYour shader presets (ReShadePreset.ini) have been preserved for future use."}
+                decky.logger.info(f'ReShadePreset.ini preserved at {preset_path}')
+                return {
+                    'status': 'success',
+                    'output': 'ReShade uninstalled successfully.\nYour shader presets (ReShadePreset.ini) have been preserved for future use.',
+                }
             else:
-                return {"status": "success", "output": "ReShade uninstalled successfully."}
+                return {'status': 'success', 'output': 'ReShade uninstalled successfully.'}
 
         except Exception as e:
-            decky.logger.error(f"Error uninstalling ReShade: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error uninstalling ReShade: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def detect_heroic_game_api(self, game_path: str) -> dict:
         """Detect the best API/DLL override for a Heroic game"""
         try:
-            decky.logger.info(f"Detecting API for Heroic game at: {game_path}")
+            decky.logger.info(f'Detecting API for Heroic game at: {game_path}')
 
             # Verify game path exists
             if not os.path.exists(game_path):
-                return {"status": "error", "message": f"Game path not found: {game_path}"}
+                return {'status': 'error', 'message': f'Game path not found: {game_path}'}
 
             # Default API is dxgi (DirectX 10/11/12)
-            detected_api = "dxgi"
-            arch = "64"  # Default to 64-bit
+            detected_api = 'dxgi'
+            arch = '64'  # Default to 64-bit
 
             # Find all executable files
             exe_files = []
             for root, _, files in os.walk(game_path):
                 for file in files:
-                    if file.lower().endswith(".exe"):
+                    if file.lower().endswith('.exe'):
                         # Skip known utility executables
-                        if any(skip in file.lower() for skip in ["unins", "launcher", "crash", "setup", "config", "redist"]):
+                        if any(
+                            skip in file.lower()
+                            for skip in ['unins', 'launcher', 'crash', 'setup', 'config', 'redist']
+                        ):
                             continue
 
                         exe_path = os.path.join(root, file)
@@ -2818,53 +3216,50 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
 
             # Process the largest executable files first
             for exe_path, _ in exe_files[:3]:  # Check the top 3 largest executables
-                decky.logger.info(f"Analyzing executable: {exe_path}")
+                decky.logger.info(f'Analyzing executable: {exe_path}')
 
                 # Check architecture
                 try:
                     # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
                     clean_env = os.environ.copy()
-                    clean_env["LD_LIBRARY_PATH"] = ""
+                    clean_env['LD_LIBRARY_PATH'] = ''
 
                     process = subprocess.run(
-                        ["file", exe_path],
-                        capture_output=True,
-                        text=True,
-                        env=clean_env
+                        ['file', exe_path], capture_output=True, text=True, env=clean_env
                     )
 
-                    if "PE32 executable" in process.stdout and "PE32+" not in process.stdout:
-                        arch = "32"
-                        decky.logger.info(f"Detected 32-bit executable: {exe_path}")
-                    elif "PE32+ executable" in process.stdout or "x86-64" in process.stdout:
-                        arch = "64"
-                        decky.logger.info(f"Detected 64-bit executable: {exe_path}")
+                    if 'PE32 executable' in process.stdout and 'PE32+' not in process.stdout:
+                        arch = '32'
+                        decky.logger.info(f'Detected 32-bit executable: {exe_path}')
+                    elif 'PE32+ executable' in process.stdout or 'x86-64' in process.stdout:
+                        arch = '64'
+                        decky.logger.info(f'Detected 64-bit executable: {exe_path}')
                 except Exception as e:
-                    decky.logger.error(f"Error checking architecture: {e!s}")
+                    decky.logger.error(f'Error checking architecture: {e!s}')
 
                 # Look for DLL files in the same directory to determine API
                 exe_dir = os.path.dirname(exe_path)
 
                 # Check for specific DLLs to determine API
-                if os.path.exists(os.path.join(exe_dir, "d3d9.dll")):
-                    detected_api = "d3d9"
-                    decky.logger.info("Detected D3D9 API from d3d9.dll")
+                if os.path.exists(os.path.join(exe_dir, 'd3d9.dll')):
+                    detected_api = 'd3d9'
+                    decky.logger.info('Detected D3D9 API from d3d9.dll')
                     break
-                elif os.path.exists(os.path.join(exe_dir, "d3d11.dll")):
-                    detected_api = "d3d11"
-                    decky.logger.info("Detected D3D11 API from d3d11.dll")
+                elif os.path.exists(os.path.join(exe_dir, 'd3d11.dll')):
+                    detected_api = 'd3d11'
+                    decky.logger.info('Detected D3D11 API from d3d11.dll')
                     break
-                elif os.path.exists(os.path.join(exe_dir, "d3d8.dll")):
-                    detected_api = "d3d8"
-                    decky.logger.info("Detected D3D8 API from d3d8.dll")
+                elif os.path.exists(os.path.join(exe_dir, 'd3d8.dll')):
+                    detected_api = 'd3d8'
+                    decky.logger.info('Detected D3D8 API from d3d8.dll')
                     break
-                elif os.path.exists(os.path.join(exe_dir, "opengl32.dll")):
-                    detected_api = "opengl32"
-                    decky.logger.info("Detected OpenGL API from opengl32.dll")
+                elif os.path.exists(os.path.join(exe_dir, 'opengl32.dll')):
+                    detected_api = 'opengl32'
+                    decky.logger.info('Detected OpenGL API from opengl32.dll')
                     break
-                elif os.path.exists(os.path.join(exe_dir, "dxgi.dll")):
-                    detected_api = "dxgi"
-                    decky.logger.info("Detected DXGI API from dxgi.dll")
+                elif os.path.exists(os.path.join(exe_dir, 'dxgi.dll')):
+                    detected_api = 'dxgi'
+                    decky.logger.info('Detected DXGI API from dxgi.dll')
                     break
 
                 # If no DLLs found, try to analyze the executable for imports
@@ -2872,56 +3267,49 @@ Note: If ReShadePreset.ini already existed, your previous settings were preserve
                     # Check imports using objdump (if available)
                     # Create environment with required LD_LIBRARY_PATH fix for Decky v3.1.10+
                     clean_env = os.environ.copy()
-                    clean_env["LD_LIBRARY_PATH"] = ""
+                    clean_env['LD_LIBRARY_PATH'] = ''
 
                     process = subprocess.run(
-                        ["objdump", "-p", exe_path],
-                        capture_output=True,
-                        text=True,
-                        env=clean_env
+                        ['objdump', '-p', exe_path], capture_output=True, text=True, env=clean_env
                     )
 
                     output = process.stdout.lower()
 
                     # Check for DLL imports
-                    if "d3d9.dll" in output:
-                        detected_api = "d3d9"
-                        decky.logger.info("Detected D3D9 API from imports")
+                    if 'd3d9.dll' in output:
+                        detected_api = 'd3d9'
+                        decky.logger.info('Detected D3D9 API from imports')
                         break
-                    elif "d3d11.dll" in output:
-                        detected_api = "d3d11"
-                        decky.logger.info("Detected D3D11 API from imports")
+                    elif 'd3d11.dll' in output:
+                        detected_api = 'd3d11'
+                        decky.logger.info('Detected D3D11 API from imports')
                         break
-                    elif "d3d8.dll" in output:
-                        detected_api = "d3d8"
-                        decky.logger.info("Detected D3D8 API from imports")
+                    elif 'd3d8.dll' in output:
+                        detected_api = 'd3d8'
+                        decky.logger.info('Detected D3D8 API from imports')
                         break
-                    elif "opengl32.dll" in output:
-                        detected_api = "opengl32"
-                        decky.logger.info("Detected OpenGL API from imports")
+                    elif 'opengl32.dll' in output:
+                        detected_api = 'opengl32'
+                        decky.logger.info('Detected OpenGL API from imports')
                         break
-                    elif "dxgi.dll" in output:
-                        detected_api = "dxgi"
-                        decky.logger.info("Detected DXGI API from imports")
+                    elif 'dxgi.dll' in output:
+                        detected_api = 'dxgi'
+                        decky.logger.info('Detected DXGI API from imports')
                         break
                 except Exception as e:
-                    decky.logger.error(f"Error analyzing imports: {e!s}")
+                    decky.logger.error(f'Error analyzing imports: {e!s}')
 
             # For 32-bit executables, default to d3d9 if not detected
-            if arch == "32" and detected_api == "dxgi":
-                detected_api = "d3d9"
-                decky.logger.info("Falling back to D3D9 for 32-bit executable")
+            if arch == '32' and detected_api == 'dxgi':
+                detected_api = 'd3d9'
+                decky.logger.info('Falling back to D3D9 for 32-bit executable')
 
-            decky.logger.info(f"Final detection - API: {detected_api}, Architecture: {arch}")
+            decky.logger.info(f'Final detection - API: {detected_api}, Architecture: {arch}')
 
-            return {
-                "status": "success",
-                "api": detected_api,
-                "architecture": arch
-            }
+            return {'status': 'success', 'api': detected_api, 'architecture': arch}
         except Exception as e:
-            decky.logger.error(f"Error detecting API for Heroic game: {e!s}")
-            return {"status": "error", "message": str(e)}
+            decky.logger.error(f'Error detecting API for Heroic game: {e!s}')
+            return {'status': 'error', 'message': str(e)}
 
     async def log_error(self, error: str) -> None:
-        decky.logger.error(f"FRONTEND: {error}")
+        decky.logger.error(f'FRONTEND: {error}')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rollup -c",
     "typecheck": "tsc --noEmit",
     "watch": "rollup -c -w",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "lint": "biome check && shellcheck defaults/assets/*.sh && python3 -m ruff check main.py",
     "lint:js": "biome check",
     "lint:js:fix": "biome check --fix",
@@ -45,7 +45,8 @@
     "@types/webpack": "^5.28.5",
     "husky": "^9.1.7",
     "rollup": "^4.22.5",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "vitest": "^4.1.6"
   },
   "dependencies": {
     "@decky/api": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rollup -c",
+    "typecheck": "tsc --noEmit",
     "watch": "rollup -c -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "biome check && shellcheck defaults/assets/*.sh && python3 -m ruff check main.py",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,23 +10,23 @@ importers:
     dependencies:
       '@decky/api':
         specifier: ^1.1.2
-        version: 1.1.3
+        version: 1.1.2
       react-icons:
         specifier: ^5.3.0
-        version: 5.6.0(react@19.2.0)
+        version: 5.5.0(react@19.2.0)
       tslib:
         specifier: ^2.7.0
         version: 2.8.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.2.5
-        version: 2.4.15
+        version: 2.2.5
       '@decky/rollup':
         specifier: ^1.0.1
-        version: 1.0.2
+        version: 1.0.1
       '@decky/ui':
         specifier: ^4.7.2
-        version: 4.11.3
+        version: 4.10.6
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
@@ -41,78 +41,90 @@ importers:
         version: 9.1.7
       rollup:
         specifier: ^4.22.5
-        version: 4.60.4
+        version: 4.52.4
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@24.7.1)(vite@8.0.13(@types/node@24.7.1)(terser@5.44.0))
 
 packages:
 
-  '@biomejs/biome@2.4.15':
-    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
+  '@biomejs/biome@2.2.5':
+    resolution: {integrity: sha512-zcIi+163Rc3HtyHbEO7CjeHq8DjQRs40HsGbW6vx2WI0tg8mYQOPouhvHSyEnCBAorfYNnKdR64/IxO7xQ5faw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
-    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
+  '@biomejs/cli-darwin-arm64@2.2.5':
+    resolution: {integrity: sha512-MYT+nZ38wEIWVcL5xLyOhYQQ7nlWD0b/4mgATW2c8dvq7R4OQjt/XGXFkXrmtWmQofaIM14L7V8qIz/M+bx5QQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.15':
-    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
+  '@biomejs/cli-darwin-x64@2.2.5':
+    resolution: {integrity: sha512-FLIEl73fv0R7dI10EnEiZLw+IMz3mWLnF95ASDI0kbx6DDLJjWxE5JxxBfmG+udz1hIDd3fr5wsuP7nwuTRdAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
-    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
+  '@biomejs/cli-linux-arm64-musl@2.2.5':
+    resolution: {integrity: sha512-5Ov2wgAFwqDvQiESnu7b9ufD1faRa+40uwrohgBopeY84El2TnBDoMNXx6iuQdreoFGjwW8vH6k68G21EpNERw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.15':
-    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
+  '@biomejs/cli-linux-arm64@2.2.5':
+    resolution: {integrity: sha512-5DjiiDfHqGgR2MS9D+AZ8kOfrzTGqLKywn8hoXpXXlJXIECGQ32t+gt/uiS2XyGBM2XQhR6ztUvbjZWeccFMoQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
-    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
+  '@biomejs/cli-linux-x64-musl@2.2.5':
+    resolution: {integrity: sha512-AVqLCDb/6K7aPNIcxHaTQj01sl1m989CJIQFQEaiQkGr2EQwyOpaATJ473h+nXDUuAcREhccfRpe/tu+0wu0eQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.15':
-    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
+  '@biomejs/cli-linux-x64@2.2.5':
+    resolution: {integrity: sha512-fq9meKm1AEXeAWan3uCg6XSP5ObA6F/Ovm89TwaMiy1DNIwdgxPkNwxlXJX8iM6oRbFysYeGnT0OG8diCWb9ew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.15':
-    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
+  '@biomejs/cli-win32-arm64@2.2.5':
+    resolution: {integrity: sha512-xaOIad4wBambwJa6mdp1FigYSIF9i7PCqRbvBqtIi9y29QtPVQ13sDGtUnsRoe6SjL10auMzQ6YAe+B3RpZXVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.15':
-    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
+  '@biomejs/cli-win32-x64@2.2.5':
+    resolution: {integrity: sha512-F/jhuXCssPFAuciMhHKk00xnCAxJRS/pUzVfXYmOMUp//XW7mO6QeCjsjvnm8L4AO/dG2VOB0O+fJPiJ2uXtIw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@decky/api@1.1.3':
-    resolution: {integrity: sha512-XsPCZxfxk5I1UtylIUN3qaWQI31siQbKfbLIskkI5innEatY1m4NQqBv/6hwPaO9mKMbdqYpnh5PSJDeMEOOBA==}
+  '@decky/api@1.1.2':
+    resolution: {integrity: sha512-lTMqRpHOrGTCyH2c1jJvkmWhOq2dcnX5/ioHbfCVmyQOBik1OM1BnzF1uROsnNDC5GkRvl3J/ATqYp6vhYpRqw==}
 
-  '@decky/rollup@1.0.2':
-    resolution: {integrity: sha512-ixuHH3msw156ACbgWZi4hgccdzDBIuqYGOVja8sLX4lHFgaWUKji1vomDi7Dk1CamgjmKt+Dqf75Pezv2FB6Bw==}
+  '@decky/rollup@1.0.1':
+    resolution: {integrity: sha512-dx1VJwD7ul14PA/aZvOwAfY/GujHzqZJ+MFb4OIUVi63/z4KWMSuZrK6QWo0S4LrNW3RzB3ua6LT0WcJaNY9gw==}
 
-  '@decky/ui@4.11.3':
-    resolution: {integrity: sha512-lA79I3isehiYpjisbrQCiqmzOOVjJaMwd8Ta3ZHVH3iNgCgeeG9F4LjkjiV3Palpx/ShDawR9H4MOsvhd/EfxA==}
+  '@decky/ui@4.10.6':
+    resolution: {integrity: sha512-1VxL260XiSHmxjiorR0Ds9r5fmvif+zbI8rrFjIqo5enbX5AjoQPOND1UNPNVBXcxzCsR3byuQFBdrK7gFdhQw==}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -134,6 +146,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -146,9 +164,110 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-commonjs@26.0.3':
     resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
@@ -208,143 +327,138 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.4':
-    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.4':
-    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+  '@rollup/rollup-android-arm64@4.52.4':
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.4':
-    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.4':
-    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+  '@rollup/rollup-darwin-x64@4.52.4':
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.4':
-    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.4':
-    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
-    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
-    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
-    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
-    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
-    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.4':
-    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.4':
-    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.4':
-    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
-    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
-    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
-    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -354,9 +468,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -380,6 +491,35 @@ packages:
 
   '@types/webpack@5.28.5':
     resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -483,6 +623,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -490,11 +634,11 @@ packages:
     resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
     hasBin: true
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -510,6 +654,10 @@ packages:
 
   caniuse-lite@1.0.30001749:
     resolution: {integrity: sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -535,6 +683,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -549,6 +700,10 @@ packages:
   del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -570,12 +725,11 @@ packages:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -610,6 +764,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -620,8 +778,17 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -649,14 +816,13 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -669,8 +835,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   husky@9.1.7:
@@ -693,8 +859,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  is-core-module@2.16.2:
-    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
@@ -750,12 +916,89 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -783,22 +1026,30 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -829,16 +1080,27 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -846,8 +1108,8 @@ packages:
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
-  react-icons@5.6.0:
-    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
     peerDependencies:
       react: '*'
 
@@ -859,8 +1121,8 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -871,6 +1133,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup-plugin-delete@2.2.0:
@@ -892,8 +1159,8 @@ packages:
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
-  rollup@4.60.4:
-    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+  rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -918,6 +1185,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -926,12 +1196,22 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -945,8 +1225,8 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
   supports-color@8.1.1:
@@ -982,6 +1262,21 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1006,6 +1301,90 @@ packages:
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -1029,6 +1408,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1042,65 +1426,81 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@2.4.15':
+  '@biomejs/biome@2.2.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.15
-      '@biomejs/cli-darwin-x64': 2.4.15
-      '@biomejs/cli-linux-arm64': 2.4.15
-      '@biomejs/cli-linux-arm64-musl': 2.4.15
-      '@biomejs/cli-linux-x64': 2.4.15
-      '@biomejs/cli-linux-x64-musl': 2.4.15
-      '@biomejs/cli-win32-arm64': 2.4.15
-      '@biomejs/cli-win32-x64': 2.4.15
+      '@biomejs/cli-darwin-arm64': 2.2.5
+      '@biomejs/cli-darwin-x64': 2.2.5
+      '@biomejs/cli-linux-arm64': 2.2.5
+      '@biomejs/cli-linux-arm64-musl': 2.2.5
+      '@biomejs/cli-linux-x64': 2.2.5
+      '@biomejs/cli-linux-x64-musl': 2.2.5
+      '@biomejs/cli-win32-arm64': 2.2.5
+      '@biomejs/cli-win32-x64': 2.2.5
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
+  '@biomejs/cli-darwin-arm64@2.2.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.15':
+  '@biomejs/cli-darwin-x64@2.2.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
+  '@biomejs/cli-linux-arm64-musl@2.2.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.15':
+  '@biomejs/cli-linux-arm64@2.2.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
+  '@biomejs/cli-linux-x64-musl@2.2.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.15':
+  '@biomejs/cli-linux-x64@2.2.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.15':
+  '@biomejs/cli-win32-arm64@2.2.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.15':
+  '@biomejs/cli-win32-x64@2.2.5':
     optional: true
 
-  '@decky/api@1.1.3': {}
+  '@decky/api@1.1.2': {}
 
-  '@decky/rollup@1.0.2':
+  '@decky/rollup@1.0.1':
     dependencies:
-      '@rollup/plugin-commonjs': 26.0.3(rollup@4.60.4)
-      '@rollup/plugin-json': 6.1.0(rollup@4.60.4)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.60.4)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.60.4)
-      '@rollup/plugin-typescript': 11.1.6(rollup@4.60.4)(tslib@2.8.1)(typescript@5.9.3)
+      '@rollup/plugin-commonjs': 26.0.3(rollup@4.52.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.52.4)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.52.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.52.4)
+      '@rollup/plugin-typescript': 11.1.6(rollup@4.52.4)(tslib@2.8.1)(typescript@5.9.3)
       merge-anything: 6.0.6
-      rollup: 4.60.4
-      rollup-plugin-delete: 2.2.0(rollup@4.60.4)
-      rollup-plugin-external-globals: 0.11.0(rollup@4.60.4)
-      rollup-plugin-import-assets: 1.1.1(rollup@4.60.4)
+      rollup: 4.52.4
+      rollup-plugin-delete: 2.2.0(rollup@4.52.4)
+      rollup-plugin-external-globals: 0.11.0(rollup@4.52.4)
+      rollup-plugin-import-assets: 1.1.1(rollup@4.52.4)
       tslib: 2.8.1
       typescript: 5.9.3
 
-  '@decky/ui@4.11.3': {}
+  '@decky/ui@4.10.6': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -1124,6 +1524,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1134,150 +1541,206 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
+      fastq: 1.19.1
+
+  '@oxc-project/types@0.130.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rollup/plugin-commonjs@26.0.3(rollup@4.60.4)':
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/plugin-commonjs@26.0.3(rollup@4.52.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      glob: 10.5.0
+      glob: 10.4.5
       is-reference: 1.2.1
-      magic-string: 0.30.21
+      magic-string: 0.30.19
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  '@rollup/plugin-json@6.1.0(rollup@4.60.4)':
+  '@rollup/plugin-json@6.1.0(rollup@4.52.4)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.60.4)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.52.4)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.12
+      resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  '@rollup/plugin-replace@5.0.7(rollup@4.60.4)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.52.4)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      magic-string: 0.30.21
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
+      magic-string: 0.30.19
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.60.4)(tslib@2.8.1)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.52.4)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
-      resolve: 1.22.12
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
+      resolve: 1.22.10
       typescript: 5.9.3
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
       tslib: 2.8.1
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
+  '@rollup/pluginutils@5.3.0(rollup@4.52.4)':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  '@rollup/rollup-android-arm-eabi@4.60.4':
+  '@rollup/rollup-android-arm-eabi@4.52.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.4':
+  '@rollup/rollup-android-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.4':
+  '@rollup/rollup-darwin-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.4':
+  '@rollup/rollup-darwin-x64@4.52.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.4':
+  '@rollup/rollup-freebsd-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.4':
+  '@rollup/rollup-freebsd-x64@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.4':
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.4':
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+  '@rollup/rollup-linux-x64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.4':
+  '@rollup/rollup-openharmony-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.4':
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.4':
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.4':
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.4':
-    optional: true
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
-  '@rollup/rollup-win32-x64-msvc@4.60.4':
-    optional: true
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
-
-  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -1308,6 +1771,47 @@ snapshots:
       - esbuild
       - uglify-js
       - webpack-cli
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@24.7.1)(terser@5.44.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@24.7.1)(terser@5.44.0)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -1428,16 +1932,18 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.8.16: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -1457,6 +1963,8 @@ snapshots:
 
   caniuse-lite@1.0.30001749: {}
 
+  chai@6.2.2: {}
+
   chrome-trace-event@1.0.4: {}
 
   clean-stack@2.2.0: {}
@@ -1472,6 +1980,8 @@ snapshots:
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1494,6 +2004,8 @@ snapshots:
       rimraf: 3.0.2
       slash: 3.0.0
 
+  detect-libc@2.1.2: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -1511,9 +2023,9 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
-  es-errors@1.3.0: {}
-
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   escalade@3.2.0: {}
 
@@ -1536,9 +2048,11 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   events@3.3.0: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -1552,9 +2066,13 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastq@1.20.1:
+  fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fill-range@7.1.1:
     dependencies:
@@ -1578,12 +2096,12 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.5.0:
+  glob@10.4.5:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -1592,7 +2110,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -1609,7 +2127,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hasown@2.0.3:
+  hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
@@ -1626,9 +2144,9 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  is-core-module@2.16.2:
+  is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -1648,11 +2166,11 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
 
   is-what@5.5.0: {}
 
@@ -1674,9 +2192,62 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   loader-runner@4.3.1: {}
 
   lru-cache@10.4.3: {}
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -1693,7 +2264,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 2.3.1
 
   mime-db@1.52.0: {}
 
@@ -1701,19 +2272,23 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  minimatch@3.1.5:
+  minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.12
 
-  minimatch@9.0.9:
+  minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.0.2
 
-  minipass@7.1.3: {}
+  minipass@7.1.2: {}
+
+  nanoid@3.3.12: {}
 
   neo-async@2.6.2: {}
 
   node-releases@2.0.23: {}
+
+  obug@2.1.1: {}
 
   once@1.4.0:
     dependencies:
@@ -1734,15 +2309,25 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
+  picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   queue-microtask@1.2.3: {}
 
@@ -1750,7 +2335,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  react-icons@5.6.0(react@19.2.0):
+  react-icons@5.5.0(react@19.2.0):
     dependencies:
       react: 19.2.0
 
@@ -1758,10 +2343,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve@1.22.12:
+  resolve@1.22.10:
     dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
+      is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -1771,22 +2355,43 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-delete@2.2.0(rollup@4.60.4):
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
+
+  rollup-plugin-delete@2.2.0(rollup@4.52.4):
     dependencies:
       del: 6.1.1
-      rollup: 4.60.4
+      rollup: 4.52.4
 
-  rollup-plugin-external-globals@0.11.0(rollup@4.60.4):
+  rollup-plugin-external-globals@0.11.0(rollup@4.52.4):
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
       estree-walker: 3.0.3
       is-reference: 3.0.3
-      magic-string: 0.30.21
-      rollup: 4.60.4
+      magic-string: 0.30.19
+      rollup: 4.52.4
 
-  rollup-plugin-import-assets@1.1.1(rollup@4.60.4):
+  rollup-plugin-import-assets@1.1.1(rollup@4.52.4):
     dependencies:
-      rollup: 4.60.4
+      rollup: 4.52.4
       rollup-pluginutils: 2.8.2
       url-join: 4.0.1
 
@@ -1794,35 +2399,32 @@ snapshots:
     dependencies:
       estree-walker: 0.6.1
 
-  rollup@4.60.4:
+  rollup@4.52.4:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.4
-      '@rollup/rollup-android-arm64': 4.60.4
-      '@rollup/rollup-darwin-arm64': 4.60.4
-      '@rollup/rollup-darwin-x64': 4.60.4
-      '@rollup/rollup-freebsd-arm64': 4.60.4
-      '@rollup/rollup-freebsd-x64': 4.60.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
-      '@rollup/rollup-linux-arm64-gnu': 4.60.4
-      '@rollup/rollup-linux-arm64-musl': 4.60.4
-      '@rollup/rollup-linux-loong64-gnu': 4.60.4
-      '@rollup/rollup-linux-loong64-musl': 4.60.4
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
-      '@rollup/rollup-linux-ppc64-musl': 4.60.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
-      '@rollup/rollup-linux-riscv64-musl': 4.60.4
-      '@rollup/rollup-linux-s390x-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-gnu': 4.60.4
-      '@rollup/rollup-linux-x64-musl': 4.60.4
-      '@rollup/rollup-openbsd-x64': 4.60.4
-      '@rollup/rollup-openharmony-arm64': 4.60.4
-      '@rollup/rollup-win32-arm64-msvc': 4.60.4
-      '@rollup/rollup-win32-ia32-msvc': 4.60.4
-      '@rollup/rollup-win32-x64-gnu': 4.60.4
-      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -1848,9 +2450,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -1858,6 +2464,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -1869,13 +2479,13 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
+  strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -1903,6 +2513,17 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -1921,6 +2542,45 @@ snapshots:
 
   url-join@4.0.1: {}
 
+  vite@8.0.13(@types/node@24.7.1)(terser@5.44.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.7.1
+      fsevents: 2.3.3
+      terser: 5.44.0
+
+  vitest@4.1.6(@types/node@24.7.1)(vite@8.0.13(@types/node@24.7.1)(terser@5.44.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.7.1)(terser@5.44.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@24.7.1)(terser@5.44.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.7.1
+    transitivePeerDependencies:
+      - msw
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -1931,7 +2591,7 @@ snapshots:
   webpack@5.102.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.9
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
@@ -1964,6 +2624,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -1974,6 +2639,6 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}

--- a/scripts/create-dev-build.js
+++ b/scripts/create-dev-build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import {
   cpSync,
   existsSync,
@@ -8,9 +8,9 @@ import {
   readFileSync,
   rmSync,
   writeFileSync,
-} from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -60,7 +60,7 @@ if (packageJson.scripts?.lint) {
   log.info('Running lint...');
   try {
     execSync('pnpm run lint', { stdio: 'inherit' });
-  } catch (error) {
+  } catch (_error) {
     log.error('Linting failed');
     process.exit(1);
   }
@@ -80,7 +80,7 @@ if (
     log.info('Running prettier...');
     try {
       execSync('pnpm run format', { stdio: 'inherit' });
-    } catch (error) {
+    } catch (_error) {
       log.error('Formatting failed');
       process.exit(1);
     }
@@ -95,7 +95,7 @@ if (testScript && !testScript.includes('no test specified')) {
   log.info('Running tests...');
   try {
     execSync('pnpm run test', { stdio: 'inherit' });
-  } catch (error) {
+  } catch (_error) {
     log.error('Tests failed');
     process.exit(1);
   }
@@ -107,7 +107,7 @@ if (testScript && !testScript.includes('no test specified')) {
 log.info('Installing dependencies...');
 try {
   execSync('pnpm install', { stdio: 'inherit' });
-} catch (error) {
+} catch (_error) {
   log.error('Failed to install dependencies');
   process.exit(1);
 }
@@ -116,7 +116,7 @@ try {
 log.info('Building plugin...');
 try {
   execSync('pnpm run build', { stdio: 'inherit' });
-} catch (error) {
+} catch (_error) {
   log.error('Build failed');
   process.exit(1);
 }
@@ -159,7 +159,7 @@ const originalPackageJson = readFileSync(packageJsonPath, 'utf8');
 const updatedPackageJson = { ...packageJson, version };
 writeFileSync(
   packageJsonPath,
-  JSON.stringify(updatedPackageJson, null, 2) + '\n',
+  `${JSON.stringify(updatedPackageJson, null, 2)}\n`,
 );
 
 log.info('Creating release package...');
@@ -197,7 +197,7 @@ writeFileSync(packageJsonPath, originalPackageJson);
 log.info(`Creating zip file: ${zipName}`);
 try {
   execSync(`zip -r "${zipName}" "${releaseDir}"`, { stdio: 'inherit' });
-} catch (error) {
+} catch (_error) {
   log.error('Failed to create zip file');
   process.exit(1);
 }

--- a/src/SteamGamesSection.tsx
+++ b/src/SteamGamesSection.tsx
@@ -337,7 +337,7 @@ const SteamGamesSection = () => {
                   const detectedApi =
                     launchOptions.match(/;(\w+)=n,b/)?.pop() || 'dxgi';
                   await SteamClient.Apps.SetAppLaunchOptions(
-                    parseInt(selectedGame.appid),
+                    parseInt(selectedGame.appid, 10),
                     launchOptions,
                   );
 
@@ -352,7 +352,7 @@ const SteamGamesSection = () => {
                 } else {
                   // Fallback if we can't extract from output
                   await SteamClient.Apps.SetAppLaunchOptions(
-                    parseInt(selectedGame.appid),
+                    parseInt(selectedGame.appid, 10),
                     `WINEDLLOVERRIDES="d3dcompiler_47=n;${dllValue}=n,b" %command%`,
                   );
                   setResult(
@@ -362,7 +362,7 @@ const SteamGamesSection = () => {
               } else {
                 // Manual DLL selection
                 await SteamClient.Apps.SetAppLaunchOptions(
-                  parseInt(selectedGame.appid),
+                  parseInt(selectedGame.appid, 10),
                   `WINEDLLOVERRIDES="d3dcompiler_47=n;${dllValue}=n,b" %command%`,
                 );
                 setResult(
@@ -416,7 +416,7 @@ const SteamGamesSection = () => {
 
             if (response.status === 'success') {
               await SteamClient.Apps.SetAppLaunchOptions(
-                parseInt(selectedGame.appid),
+                parseInt(selectedGame.appid, 10),
                 '',
               );
               setResult(

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('placeholder', () => {
+  it('should pass', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('placeholder', () => {
   it('should pass', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,7 @@ function ReShadeInstallerSection() {
           setAddonEnabled(result.is_addon);
           // Set version dropdown to match currently installed version
           if (!selectedVersion) {
-            if (result.version_info && result.version_info.version) {
+            if (result.version_info?.version) {
               // Find the matching version option based on installed version
               const installedVersion = result.version_info.version;
               const matchingOption = versionOptions.find(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration - mock the decky module so main.py can be imported."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+# Create a mock decky module before any test imports main
+mock_decky = ModuleType('decky')
+mock_decky.logger = MagicMock()
+mock_decky.DECKY_PLUGIN_DIR = '/tmp/test_plugin'
+mock_decky.HOME = '/tmp/test_home'
+sys.modules['decky'] = mock_decky

--- a/tests/test_score_executable.py
+++ b/tests/test_score_executable.py
@@ -1,9 +1,6 @@
 """Tests for executable scoring functions in main.py."""
 
-import pytest
-
 from main import score_heroic_executable, score_steam_executable
-
 
 # --- Helpers ---
 
@@ -55,7 +52,9 @@ class TestScoreSteamExecutable:
         assert score_normal > score_launcher
 
     def test_unreal_engine_patterns_boost(self):
-        exe = make_exe('MyGame-Win64-Shipping.exe', 'Binaries/Win64/MyGame-Win64-Shipping.exe', size_mb=80.0)
+        exe = make_exe(
+            'MyGame-Win64-Shipping.exe', 'Binaries/Win64/MyGame-Win64-Shipping.exe', size_mb=80.0
+        )
         score = score_steam_executable(exe, 'MyGame')
         # Should get path bonus + shipping bonus + size bonus + name match
         assert score > 80

--- a/tests/test_score_executable.py
+++ b/tests/test_score_executable.py
@@ -1,0 +1,134 @@
+"""Tests for executable scoring functions in main.py."""
+
+import pytest
+
+from main import score_heroic_executable, score_steam_executable
+
+
+# --- Helpers ---
+
+
+def make_exe(filename, rel_path='', size_mb=10.0):
+    """Create an exe_info dict for testing."""
+    return {
+        'filename': filename,
+        'relative_path': rel_path or filename,
+        'size_mb': size_mb,
+    }
+
+
+# --- score_steam_executable tests ---
+
+
+class TestScoreSteamExecutable:
+    def test_exact_name_match_scores_highest(self):
+        exe = make_exe('Cyberpunk2077.exe', 'Cyberpunk2077.exe')
+        score = score_steam_executable(exe, 'Cyberpunk 2077')
+        assert score > 90
+
+    def test_partial_name_match(self):
+        exe = make_exe('witcher3.exe', 'witcher3.exe')
+        score = score_steam_executable(exe, 'The Witcher 3 Wild Hunt')
+        # Should get some word match but not exact
+        assert score > 50
+
+    def test_common_game_exe_name_bonus(self):
+        exe = make_exe('game.exe', 'game.exe')
+        score_with_bonus = score_steam_executable(exe, 'Some Random Game')
+        exe_no_bonus = make_exe('randomthing.exe', 'randomthing.exe')
+        score_without = score_steam_executable(exe_no_bonus, 'Some Random Game')
+        # 'game' keyword should boost score
+        assert score_with_bonus > score_without
+
+    def test_large_file_scores_higher_than_tiny(self):
+        exe_large = make_exe('unknown.exe', 'unknown.exe', size_mb=100.0)
+        exe_tiny = make_exe('unknown.exe', 'unknown.exe', size_mb=0.1)
+        score_large = score_steam_executable(exe_large, 'SomeGame')
+        score_tiny = score_steam_executable(exe_tiny, 'SomeGame')
+        assert score_large > score_tiny
+
+    def test_launcher_gets_penalty(self):
+        exe_launcher = make_exe('gamelauncher.exe', 'gamelauncher.exe')
+        exe_normal = make_exe('game.exe', 'game.exe')
+        score_launcher = score_steam_executable(exe_launcher, 'SomeGame')
+        score_normal = score_steam_executable(exe_normal, 'SomeGame')
+        assert score_normal > score_launcher
+
+    def test_unreal_engine_patterns_boost(self):
+        exe = make_exe('MyGame-Win64-Shipping.exe', 'Binaries/Win64/MyGame-Win64-Shipping.exe', size_mb=80.0)
+        score = score_steam_executable(exe, 'MyGame')
+        # Should get path bonus + shipping bonus + size bonus + name match
+        assert score > 80
+
+    def test_deep_nesting_penalty(self):
+        exe_shallow = make_exe('unknown.exe', 'unknown.exe', size_mb=10.0)
+        exe_deep = make_exe('unknown.exe', 'a/b/c/d/e/f/unknown.exe', size_mb=10.0)
+        score_shallow = score_steam_executable(exe_shallow, 'SomeGame')
+        score_deep = score_steam_executable(exe_deep, 'SomeGame')
+        assert score_shallow > score_deep
+
+    def test_score_capped_at_100(self):
+        # Perfect match with all bonuses
+        exe = make_exe('game.exe', 'game.exe', size_mb=100.0)
+        score = score_steam_executable(exe, 'game')
+        assert score <= 100
+
+    def test_score_minimum_zero(self):
+        # Tiny file, deep nesting, launcher name
+        exe = make_exe('launcher.exe', 'a/b/c/d/e/f/g/h/launcher.exe', size_mb=0.01)
+        score = score_steam_executable(exe, 'UnrelatedName')
+        assert score >= 0
+
+    def test_bin_directory_bonus(self):
+        exe_bin = make_exe('unknown.exe', 'bin/unknown.exe')
+        exe_root = make_exe('unknown.exe', 'unknown.exe')
+        score_bin = score_steam_executable(exe_bin, 'SomeGame')
+        score_root = score_steam_executable(exe_root, 'SomeGame')
+        assert score_bin > score_root
+
+
+# --- score_heroic_executable tests ---
+
+
+class TestScoreHeroicExecutable:
+    def test_utility_exe_filtered_out(self):
+        for util_name in ['unins000.exe', 'setup.exe', 'vcredist_x64.exe', 'directx_jun.exe']:
+            exe = make_exe(util_name, util_name)
+            score = score_heroic_executable(exe, 'SomeGame', '/games/SomeGame')
+            assert score == 0, f'{util_name} should be filtered out'
+
+    def test_exact_name_match(self):
+        exe = make_exe('DREDGE.exe', 'DREDGE.exe')
+        score = score_heroic_executable(exe, 'DREDGE', '/games/DREDGE')
+        assert score > 90
+
+    def test_dir_name_match(self):
+        exe = make_exe('DREDGE.exe', 'DREDGE.exe')
+        score = score_heroic_executable(exe, 'Some Other Name', '/games/DREDGE')
+        # Should match via directory name
+        assert score > 80
+
+    def test_space_normalized_match(self):
+        exe = make_exe('amongus.exe', 'amongus.exe')
+        score = score_heroic_executable(exe, 'Among Us', '/games/Among Us')
+        assert score > 80
+
+    def test_launcher_penalty(self):
+        exe_launcher = make_exe('gamelauncher.exe', 'gamelauncher.exe')
+        exe_game = make_exe('game.exe', 'game.exe')
+        score_launcher = score_heroic_executable(exe_launcher, 'MyGame', '/games/MyGame')
+        score_game = score_heroic_executable(exe_game, 'MyGame', '/games/MyGame')
+        assert score_game > score_launcher
+
+    def test_partial_match_with_extra_chars_in_dir(self):
+        # Simulates dirs like "DREDGEmKMzX" from store downloads
+        exe = make_exe('DREDGE.exe', 'DREDGE.exe')
+        score = score_heroic_executable(exe, 'DREDGE', '/games/DREDGEmKMzX')
+        assert score > 70
+
+    def test_unreal_path_bonus(self):
+        exe = make_exe('unknown.exe', 'Binaries/Win64/unknown.exe', size_mb=50.0)
+        score = score_heroic_executable(exe, 'MyGame', '/games/MyGame')
+        exe_root = make_exe('unknown.exe', 'unknown.exe', size_mb=50.0)
+        score_root = score_heroic_executable(exe_root, 'MyGame', '/games/MyGame')
+        assert score > score_root

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strict": true,
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

Make CI catch more problems that don't require a physical Steam Deck to detect.

## Changes

1. **TypeScript type checking** (`tsc --noEmit`) — catches type errors that Biome and Rollup miss
2. **Ruff format check** — enforces consistent Python formatting in CI
3. **pnpm audit** — flags known vulnerabilities in production dependencies
4. **Python unit tests** (pytest, 17 tests) — validates executable scoring/detection heuristics without needing a Deck
5. **Vitest scaffold** — ready for TypeScript unit tests, replaces the placeholder test script
6. **Fix pre-existing Biome issues** — migrate schema to 2.2.5, apply auto-fixes

## Refactoring note

The `score_executable` closures in `main.py` (inside `find_game_executable_enhanced` and `find_heroic_game_executable_path`) were extracted to module-level functions (`score_steam_executable` and `score_heroic_executable`). The logic is **identical** — only the function signature changed to accept `game_name` and `logger` as parameters instead of capturing them from closure scope. This makes them testable.

## CI Jobs (new)

| Job | What it checks |
|-----|---------------|
| `typecheck` | `tsc --noEmit` |
| `lint-py` | ruff check + ruff format --check |
| `test-python` | pytest (scoring logic) |
| `test-js` | vitest |
| `build` | pnpm audit + rollup build |

All checks pass locally.