### PR TITLE
chore: add dev-test script for local plugin testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:py:fix": "python3 -m ruff check --fix main.py",
     "format:py": "python3 -m ruff format main.py",
     "dev-build": "node scripts/create-dev-build.js",
+    "dev-test": "bash scripts/dev-test.sh",
     "prepare": "husky"
   },
   "repository": {

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_DIR="$HOME/homebrew/plugins/LetMeReShade"
+BACKUP_DIR="$HOME/homebrew/plugins/.LetMeReShade.backup"
+
+# Cache sudo credentials once
+sudo -v
+
+# Ensure we restore the backup even if something goes wrong after deployment
+restore_backup() {
+  if [ -d "$BACKUP_DIR" ]; then
+    echo "Restoring original plugin (sudo may be required)..."
+    sudo -v
+    sudo rm -rf "$PLUGIN_DIR"
+    sudo mv "$BACKUP_DIR" "$PLUGIN_DIR"
+    sudo systemctl restart plugin_loader.service
+    echo "Restored original plugin and restarted Decky Loader."
+  fi
+}
+
+# 1. Build the plugin
+pnpm run build
+
+# 2. Back up existing plugin
+if [ -d "$PLUGIN_DIR" ]; then
+  sudo rm -rf "$BACKUP_DIR"
+  sudo mv "$PLUGIN_DIR" "$BACKUP_DIR"
+  echo "Backed up existing plugin to $BACKUP_DIR"
+fi
+
+# Restore backup on exit (covers both normal exit and interrupts)
+trap restore_backup EXIT
+
+# 3. Deploy to plugins directory
+sudo mkdir -p "$PLUGIN_DIR/dist" "$PLUGIN_DIR/defaults"
+sudo cp -r dist/* "$PLUGIN_DIR/dist/"
+sudo cp -r defaults/* "$PLUGIN_DIR/defaults/"
+sudo cp main.py package.json plugin.json "$PLUGIN_DIR/"
+sudo sed -i 's/"version": "\([^"]*\)"/"version": "\1-dev"/' "$PLUGIN_DIR/package.json"
+echo "Dev build deployed to $PLUGIN_DIR"
+
+# 4. Restart Decky so it loads the new plugin
+sudo systemctl restart plugin_loader.service
+echo "Decky Loader restarted."
+
+# 5. Launch gamescope with Steam gamepadui
+echo "Launching gamescope..."
+gamescope -- steam -gamepadui
+
+# 6. Restore happens automatically via the EXIT trap
+echo "Gamescope exited."


### PR DESCRIPTION
Adds `scripts/dev-test.sh` and `pnpm dev-test` command for local plugin testing via nested gamescope.

## What it does

1. Builds the plugin (`pnpm build`)
2. Backs up the existing Decky plugin installation
3. Deploys the dev build to `~/homebrew/plugins/` with a `-dev` version suffix
4. Restarts Decky Loader to pick up changes
5. Launches nested gamescope with Steam gamepadui
6. Restores the original plugin and restarts Decky on exit

## Usage

```bash
pnpm dev-test
```