### PR TITLE
ci: add experimental build workflow triggered by PR label

### DIFF
--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -1,0 +1,101 @@
+name: Experimental Build
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  experimental-build:
+    if: github.event.label.name == 'test-build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build plugin
+        run: pnpm run build
+
+      - name: Create release package
+        run: |
+          SHORT_SHA="${{ github.event.pull_request.head.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          ZIP_NAME="LetUsReShade_experimental_${SHORT_SHA}.zip"
+          RELEASE_DIR="LetUsReShade"
+
+          mkdir -p "${RELEASE_DIR}"
+
+          cp -r dist "${RELEASE_DIR}/"
+          cp -r defaults "${RELEASE_DIR}/"
+          cp main.py "${RELEASE_DIR}/"
+          cp package.json "${RELEASE_DIR}/"
+          cp plugin.json "${RELEASE_DIR}/"
+          cp LICENSE "${RELEASE_DIR}/"
+          cp README.md "${RELEASE_DIR}/"
+
+          zip -r "${ZIP_NAME}" "${RELEASE_DIR}"
+
+          echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        id: upload
+        with:
+          name: experimental-build-${{ env.SHORT_SHA }}
+          path: ${{ env.ZIP_NAME }}
+          retention-days: 30
+
+      - name: Find existing bot comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- experimental-build -->'
+
+      - name: Post or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- experimental-build -->
+            **Experimental Build**
+
+            Branch: `${{ env.BRANCH }}` @ `${{ env.SHORT_SHA }}`
+            [Download artifact](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            > Download the zip from the Artifacts section at the bottom of the linked page.
+
+            *Updated: ${{ github.event.pull_request.updated_at }}*
+
+      - name: Remove test-build label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'test-build'
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that creates test builds from PRs for sharing with users.

## How it works

1. Add the `test-build` label to any PR
2. The workflow builds the plugin from the PR branch
3. A comment is posted (or updated) on the PR with a link to download the artifact
4. The label is auto-removed so it can be re-added for subsequent builds

## Details

- **Trigger**: `pull_request` `labeled` event, filtered to `test-build` label
- **Artifact retention**: 30 days
- **Comment**: Uses `peter-evans/find-comment` + `peter-evans/create-or-update-comment` to maintain a single comment (no spam)
- **Label cleanup**: Auto-removes `test-build` label after build via `actions/github-script`

## Usage

When a user reports an issue and a fix is in a PR, add the `test-build` label to generate a build, then share the download link from the PR comment in the issue.