### PR TITLE
ci: add pre-release workflow triggered by label on release-please PR

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,151 @@
+name: Pre-release
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pre-release:
+    if: >-
+      github.event.label.name == 'pre-release' &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        id: version
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          # Extract version from "chore(main): release X.Y.Z"
+          VERSION=$(echo "$TITLE" | grep -oP '\d+\.\d+\.\d+')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from PR title: $TITLE"
+            exit 1
+          fi
+          echo "base_version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine RC number
+        id: rc
+        run: |
+          VERSION="${{ steps.version.outputs.base_version }}"
+          # Find existing rc tags for this version and increment
+          LAST_RC=$(git tag -l "v${VERSION}-rc.*" | sort -V | tail -1 | grep -oP 'rc\.\K\d+' || echo "0")
+          NEXT_RC=$((LAST_RC + 1))
+          TAG="v${VERSION}-rc.${NEXT_RC}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "rc_number=${NEXT_RC}" >> "$GITHUB_OUTPUT"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build plugin
+        run: pnpm run build
+
+      - name: Create release package
+        run: |
+          TAG="${{ steps.rc.outputs.tag }}"
+          VERSION="${TAG#v}"
+          RELEASE_DIR="LetUsReShade"
+          ZIP_NAME="LetUsReShade_v${VERSION}.zip"
+
+          mkdir -p "${RELEASE_DIR}"
+
+          cp -r dist "${RELEASE_DIR}/"
+          cp -r defaults "${RELEASE_DIR}/"
+          cp main.py "${RELEASE_DIR}/"
+          cp package.json "${RELEASE_DIR}/"
+          cp plugin.json "${RELEASE_DIR}/"
+          cp LICENSE "${RELEASE_DIR}/"
+          cp README.md "${RELEASE_DIR}/"
+
+          zip -r "${ZIP_NAME}" "${RELEASE_DIR}"
+
+          echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
+
+      - name: Fetch release notes from release-please PR
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the release-please PR body and extract the clean changelog section
+          # The PR body format is:
+          #   :robot: I have created a release *beep* *boop*
+          #   ---
+          #   ## [1.9.0](...) (2026-05-19)
+          #   ...
+          #   ---
+          #   This PR was generated with [Release Please]...
+          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body)
+
+          # Extract content between first '---' and last '---' (the clean changelog)
+          CHANGELOG=$(echo "$PR_BODY" | awk '/^---$/{if(!found){found=1;next}} /^---$/{exit} found')
+
+          # Prepend the RC tag to the release notes
+          {
+            echo "**${{ steps.rc.outputs.tag }}**"
+            echo ""
+            echo "$CHANGELOG"
+          } > release_notes.md
+
+          echo "notes_file=release_notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.rc.outputs.tag }}"
+          gh release create "$TAG" \
+            "$ZIP_NAME" \
+            --title "$TAG" \
+            --prerelease \
+            --notes-file "${{ steps.notes.outputs.notes_file }}"
+
+      - name: Find existing bot comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- pre-release -->'
+
+      - name: Post or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- pre-release -->
+            **Pre-release: `${{ steps.rc.outputs.tag }}`**
+
+            [Download from releases](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.rc.outputs.tag }})
+
+            *Created: ${{ github.event.pull_request.updated_at }}*
+
+      - name: Remove pre-release label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'pre-release'
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that creates pre-releases from `main` when the `pre-release` label is added to the release-please PR.

## How it works

1. Release-please has an open PR (e.g. `chore(main): release 1.9.0`)
2. Add the `pre-release` label to that PR
3. The workflow:
   - Extracts the version from the PR title (`1.9.0`)
   - Finds existing `v1.9.0-rc.*` tags and increments (`rc.1`, `rc.2`, ...)
   - Builds the plugin from `main`
   - **Fetches the clean changelog from the release-please PR body** (strips the "beep boop" boilerplate)
   - Prepends the RC tag (e.g. `**v1.9.0-rc.1**`)
   - Creates a GitHub pre-release tagged `v1.9.0-rc.1` with the same curated changelog as the final release (hidden from Latest)
   - Posts/updates a comment on the PR with the download link
   - Auto-removes the `pre-release` label

4. Push more changes to `main`, add label again -> `v1.9.0-rc.2`
5. When ready, merge the release-please PR -> stable `v1.9.0` release as normal

## Details

- **Trigger**: `pull_request` `labeled` event, filtered to `pre-release` label + release-please branch
- **Pre-release**: Marked as pre-release in GitHub (hidden from Latest release)
- **Changelog**: Extracted from the release-please PR body — identical to the final release notes, with RC tag prepended
- **Comment**: Single updating comment (no spam)
- **Label cleanup**: Auto-removed after build