### PR TITLE
ci: automatically clean up pre-releases when stable release is published

### DIFF
--- a/.github/workflows/cleanup-pre-releases.yml
+++ b/.github/workflows/cleanup-pre-releases.yml
@@ -1,0 +1,46 @@
+name: Cleanup Pre-releases
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: '!github.event.release.prerelease'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version and clean up RCs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+
+          echo "Stable release published: ${TAG}"
+          echo "Looking for pre-releases matching v${VERSION}-rc.* ..."
+
+          # List all releases and filter for RCs of this version
+          RC_RELEASES=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --limit 100 \
+            --json tagName,isPrerelease \
+            --jq ".[] | select(.isPrerelease and (.tagName | startswith(\"v${VERSION}-rc.\"))) | .tagName")
+
+          if [ -z "$RC_RELEASES" ]; then
+            echo "No pre-releases found for v${VERSION}. Nothing to clean up."
+            exit 0
+          fi
+
+          echo "Found pre-releases to clean up:"
+          echo "$RC_RELEASES"
+
+          # Delete each pre-release (keeps git tags)
+          echo "$RC_RELEASES" | while read -r rc_tag; do
+            echo "Deleting pre-release: ${rc_tag}"
+            gh release delete "$rc_tag" --yes --repo "${{ github.repository }}"
+          done
+
+          echo "Cleanup complete."


### PR DESCRIPTION
## Summary

Automatically removes pre-release entries from the GitHub releases page when a stable release is published.

## How it works

1. A stable release is published (e.g. `v1.9.0`)
2. This workflow triggers automatically
3. It finds all pre-releases matching `v1.9.0-rc.*`
4. Deletes each pre-release entry from GitHub (git tags are preserved)
5. The releases page stays clean — only the stable release remains visible

## Details

- **Trigger**: `release` `published` event
- **Skip condition**: If the published release is itself a pre-release, nothing is cleaned up
- **Scope**: Only pre-releases for the same version as the stable release
- **Safety**: Only deletes GitHub release entries, never git tags

## Example

- `v1.9.0-rc.1` published → no cleanup (it's a pre-release)
- `v1.9.0` published → finds and deletes `v1.9.0-rc.1`
- Releases page shows only `v1.9.0` under Latest