### PR TITLE
ci: request review on automated ReShade version update PRs

### DIFF
--- a/.github/workflows/update-reshade.yml
+++ b/.github/workflows/update-reshade.yml
@@ -38,3 +38,4 @@ jobs:
           branch: chore/auto-reshade-update
           delete-branch: true
           labels: automated,dependencies
+          reviewers: Cliffback


### PR DESCRIPTION
## Summary

Adds a reviewer request to the automated ReShade version update PRs so they appear in GitHub notifications.

## Change

The `update-reshade` workflow now includes `reviewers: Cliffback` when creating PRs. This ensures you get a review request notification whenever a new ReShade version is available, making it easy to spot in your GitHub notifications inbox.

## Why reviewer (not assignee)

Semantically, a dependency update PR is something to **review**, not a task to be owned. Review requests show up in the dedicated "Review requests" tab and are the standard way to request attention on a PR.