### PR TITLE
ci: use repository owner as reviewer for ReShade update PRs

### DIFF
--- a/.github/workflows/update-reshade.yml
+++ b/.github/workflows/update-reshade.yml
@@ -38,4 +38,4 @@ jobs:
           branch: chore/auto-reshade-update
           delete-branch: true
           labels: automated,dependencies
-          reviewers: Cliffback
+          reviewers: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

Replaces the hardcoded reviewer username with the dynamic repository owner.

## Change

Uses `${{ github.repository_owner }}` instead of hardcoded `Cliffback` for the reviewer request on automated ReShade version update PRs.

## Benefits

- Works correctly if the repository is forked (requests review from the fork owner)
- Works correctly if the repository is transferred to another user
- No hardcoded usernames in workflow files