### PR TITLE
refactor(ci): simplify experimental build comment

### DIFF
--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           SHORT_SHA="${{ github.event.pull_request.head.sha }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           ZIP_NAME="LetUsReShade_experimental_${SHORT_SHA}.zip"
           RELEASE_DIR="LetUsReShade"
 
@@ -54,7 +53,7 @@ jobs:
 
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
           echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
-          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -80,14 +79,9 @@ jobs:
           edit-mode: replace
           body: |
             <!-- experimental-build -->
-            **Experimental Build**
+            **Generated Experimental Build**: [Download artifact](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload.outputs.artifact-id }}) (${{ env.SHORT_SHA }})
 
-            Branch: `${{ env.BRANCH }}` @ `${{ env.SHORT_SHA }}`
-            [Download artifact](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-            > Download the zip from the Artifacts section at the bottom of the linked page.
-
-            *Updated: ${{ github.event.pull_request.updated_at }}*
+            <sub>Built on ${{ env.BUILD_DATE }}</sub>
 
       - name: Remove test-build label
         uses: actions/github-script@v7


### PR DESCRIPTION
Simplifies the experimental build bot comment on PRs.

### Before
```
**Experimental Build**

Branch: `feat/non-steam-games` @ `8f1d0a0`
[Download artifact](...)

> Download the zip from the Artifacts section at the bottom of the linked page.

*Updated: 2026-05-20T19:56:58Z*
```

### After
```
**Generated Experimental Build**: [Download artifact](...) (8f1d0a0)

<sub>Built on 2026-05-20</sub>
```

### Changes
- Drops the branch name (visible on PR page already)
- Drops the explicit commit link (GitHub auto-links the SHA)
- Removes the redundant "Download the zip..." hint
- Removes the "Updated" timestamp
- Adds a subtle build date at the bottom