### PR TITLE
fix: add missing d3d12 entry in COMMON_OVERRIDES

### DIFF
--- a/defaults/assets/reshade-game-manager.sh
+++ b/defaults/assets/reshade-game-manager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COMMON_OVERRIDES="d3d8 d3d9 d3d11 ddraw dinput8 dxgi opengl32"
+COMMON_OVERRIDES="d3d8 d3d9 d3d11 d3d12 ddraw dinput8 dxgi opengl32"
 XDG_DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
 MAIN_PATH=${MAIN_PATH:-"$XDG_DATA_HOME/reshade"}
 RESHADE_PATH="$MAIN_PATH/reshade"


### PR DESCRIPTION
### Summary
`d3d12` was missing from the `COMMON_OVERRIDES` array, which in turn could lead to problems during cleanup / uninstalling

COMMON_OVERRIDES="d3d8 d3d9 d3d11 ddraw dinput8 dxgi opengl32"
`d3d12` is missing from this list.